### PR TITLE
Allows you to change exofab output dir

### DIFF
--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -103,6 +103,17 @@
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Storing up to <b>[rmat.local_size]</b> material units.<br>Material consumption at <b>[component_coeff*100]%</b>.<br>Build time reduced by <b>[100-time_coeff*100]%</b>.")
+	if(panel_open)
+		. += span_notice("Alt-click to rotate the output direction.")
+
+/obj/machinery/mecha_part_fabricator/AltClick(mob/user)
+	. = ..()
+	if(!user.Adjacent(src))
+		return
+	if(panel_open)
+		dir = turn(dir, -90)
+		balloon_alert(user, "rotated to [dir2text(dir)].")
+		return TRUE
 
 /**
  * Generates an info list for a given part.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Press ALT on an unscrewed exofab to change it's output dir.

## Why It's Good For The Game

Quality of life.

## Changelog
:cl:
qol: Alt-click an exosuit fabricater while it's maintenance panel is open to change it's output direction!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
