### PR TITLE
Returns the insulated gloves to their previous glory

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -70574,13 +70574,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"nhf" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/lights/mixed,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "nhi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random{
@@ -110514,6 +110507,13 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
+"xCC" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/turf_decal/bot,
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/iron,
+/area/commons/storage/primary)
 "xCG" = (
 /mob/living/simple_animal/hostile/cockroach,
 /turf/open/floor/plating,
@@ -145711,7 +145711,7 @@ fxY
 mMy
 kDZ
 gXU
-nhf
+xCC
 kDZ
 ncF
 eUy

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -21068,16 +21068,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors)
-"dgO" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/clothing/gloves/color/fyellow,
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "dgQ" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -44049,12 +44039,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
-"qlL" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "qlY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -46002,6 +45986,16 @@
 /obj/effect/spawner/lootdrop/techstorage/rnd_secure,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
+"rwM" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/iron,
+/area/commons/storage/primary)
 "rxq" = (
 /obj/item/restraints/legcuffs/beartrap,
 /obj/item/restraints/legcuffs/beartrap,
@@ -76486,7 +76480,7 @@ ndn
 hOt
 dpg
 hOt
-dgO
+rwM
 usd
 aLE
 avK
@@ -82715,7 +82709,7 @@ caq
 caq
 caq
 caq
-qlL
+caq
 upD
 bCq
 bCq

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -47277,25 +47277,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
-"fMq" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/item/clothing/head/welding{
-	pixel_y = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Tool Storage";
-	name = "engineering camera";
-	network = list("ss13","engine")
-	},
-/obj/structure/cable,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/iron/dark,
-/area/commons/storage/primary)
 "fMz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
@@ -79379,6 +79360,25 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/library)
+"tKU" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/clothing/head/welding{
+	pixel_y = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Tool Storage";
+	name = "engineering camera";
+	network = list("ss13","engine")
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/iron/dark,
+/area/commons/storage/primary)
 "tKZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -124179,7 +124179,7 @@ bYW
 bBj
 cWK
 cWK
-fMq
+tKU
 ttO
 dCd
 pCV

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -17349,12 +17349,6 @@
 /mob/living/simple_animal/pet/fox/renault,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
-"dtM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/item/stack/cable_coil,
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "dtO" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -70199,6 +70193,24 @@
 /mob/living/simple_animal/mouse/brown/tom,
 /turf/open/floor/plating,
 /area/security/prison/safe)
+"uUv" = (
+/obj/machinery/light/directional/east,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/lights/mixed,
+/obj/item/stack/sheet/iron{
+	amount = 30
+	},
+/obj/item/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stack/cable_coil,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/iron,
+/area/commons/storage/primary)
 "uUx" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/hangover,
@@ -71332,6 +71344,11 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"vmg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil,
+/turf/open/floor/iron,
+/area/commons/storage/primary)
 "vmw" = (
 /obj/machinery/door/window/northright{
 	base_state = "left";
@@ -74504,23 +74521,6 @@
 "wpL" = (
 /turf/closed/wall,
 /area/commons/toilet/restrooms)
-"wpN" = (
-/obj/machinery/light/directional/east,
-/obj/structure/table/reinforced,
-/obj/item/storage/box/lights/mixed,
-/obj/item/stack/sheet/iron{
-	amount = 30
-	},
-/obj/item/radio{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil,
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "wpP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -102828,7 +102828,7 @@ aaa
 cvc
 pIp
 lHv
-dtM
+vmg
 kQs
 aPL
 cvc
@@ -103344,7 +103344,7 @@ eff
 xWZ
 qdX
 hDR
-wpN
+uUv
 cvc
 vDJ
 bef

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -2,7 +2,7 @@
 	dying_key = DYE_REGISTRY_GLOVES
 
 /obj/item/clothing/gloves/color/yellow
-	desc = "These gloves provide protection against electric shock. The thickness of the rubber makes your fingers seem bigger."
+	desc = "These gloves provide protection against electric shock."
 	name = "insulated gloves"
 	icon_state = "yellow"
 	inhand_icon_state = "ygloves"
@@ -12,7 +12,6 @@
 	custom_price = PAYCHECK_MEDIUM * 10
 	custom_premium_price = PAYCHECK_COMMAND * 6
 	cut_type = /obj/item/clothing/gloves/cut
-	clothing_traits = list(TRAIT_CHUNKYFINGERS)
 
 /obj/item/toy/sprayoncan
 	name = "spray-on insulation applicator"


### PR DESCRIPTION
## About The Pull Request

the insulated gloves have the chubby finger trait no more, in addition they now spawn in the tool storage as they should.
also fixes the missing spot in the icebox's maint pipeline.

## Why It's Good For The Game

you dont need to take the insuls off to use a tablet or something and the insuls fights are back.

## Changelog
:cl:
qol: insuls no longer have the chubby finger trait
balance: the insuls in the tool storages are back
/:cl: