### PR TITLE
Re-adds 2 shuttles

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -8,6 +8,8 @@
 	var/description
 	var/prerequisites
 	var/admin_notes
+	///If the shuttle can only be bought if the console is emagged.
+	var/restricted = FALSE
 	/// How much does this shuttle cost the cargo budget to purchase? Put in terms of CARGO_CRATE_VALUE to properly scale the cost with the current balance of cargo's income.
 	var/credit_cost = INFINITY
 	/// What job accesses can buy this shuttle? If null, this shuttle cannot be bought.
@@ -257,10 +259,10 @@
 /datum/map_template/shuttle/emergency/discoinferno
 	suffix = "discoinferno"
 	name = "Disco Inferno"
-	description = "The glorious results of centuries of plasma research done by Nanotrasen employees. This is the reason why you are here. Get on and dance like you're on fire, burn baby burn!"
+	description = "A monopoly on plasma is the reason why those NT dogs have a stranglehold on the market. We've hijacked this shuttle and replaced the floor tiles with plasma. What's that saying again, reap what you sow?"
 	admin_notes = "Flaming hot. The main area has a dance machine as well as plasma floor tiles that will be ignited by players every single time."
 	credit_cost = CARGO_CRATE_VALUE * 20
-	who_can_purchase = null
+	restricted = TRUE
 
 /datum/map_template/shuttle/emergency/arena
 	suffix = "arena"
@@ -402,7 +404,8 @@
 	description = "How was space work today? Oh, pretty good. We got a new space station and the company will make a lot of money. What space station? I cannot tell you; it's space confidential. \
 	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
 	admin_notes = "Tiny, with a single airlock and wooden walls. What could go wrong?"
-	who_can_purchase = null
+	credit_cost = CARGO_CRATE_VALUE * 4
+	restricted = TRUE
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/goon

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -556,6 +556,9 @@
 	if (isnull(shuttle_template.who_can_purchase))
 		return FALSE
 
+	if (!(obj_flags & EMAGGED) && shuttle_template.restricted)
+		return FALSE
+
 	for (var/access in authorize_access)
 		if (access in shuttle_template.who_can_purchase)
 			return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Oh, Hi Daniel
Disco inferno

## Why It's Good For The Game

You now get them via emagging the console ONLY. It's not impossible to buy them anymore, but it requires a traitor to emag the console AND buy the thing, which shows their name in full to everyone.

I doubt this will lead to scenarios where oh hi daniel gets bought the majority of rounds.

## Changelog
:cl:
expansion: If you can emag the communications console, you'll find two old shuttles return...
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
