### PR TITLE
Brings back the old emag, slightly nerfed

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1197,10 +1197,9 @@
 	//Airlock is passable if it is open (!density), bot has access, and is not bolted shut or powered off)
 	return !density || (check_access(ID) && !locked && hasPower())
 
-/obj/machinery/door/airlock/emag_act(mob/user, obj/item/card/emag/doorjack/D)
+/obj/machinery/door/airlock/emag_act(mob/user, obj/item/card/emag/E)
 	if(!operating && density && hasPower() && !(obj_flags & EMAGGED))
-		if(istype(D, /obj/item/card/emag))
-			D.use_charge(user)
+		E.use_charge(user)
 		operating = TRUE
 		update_icon(ALL, AIRLOCK_EMAG, 1)
 		sleep(6)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1199,7 +1199,7 @@
 
 /obj/machinery/door/airlock/emag_act(mob/user, obj/item/card/emag/doorjack/D)
 	if(!operating && density && hasPower() && !(obj_flags & EMAGGED))
-		if(istype(D, /obj/item/card/emag/doorjack))
+		if(istype(D, /obj/item/card/emag))
 			D.use_charge(user)
 		operating = TRUE
 		update_icon(ALL, AIRLOCK_EMAG, 1)

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -18,13 +18,17 @@
 	slot_flags = ITEM_SLOT_ID
 	worn_icon_state = "emag"
 	var/prox_check = TRUE //If the emag requires you to be in range
-	var/consumer_types = list(
-		typesof(/obj/machinery/door/airlock),
-		typesof(/obj/machinery/door/window/))//List of types that consume a charge upon hacking
+	var/list/consumer_types //List of types that consume a charge upon hacking
 	var/charges = 3 //How many charges do we currently have
 	var/max_charges = 3 //How many charges can we hold in total
-	var/list/charge_timers = list()
 	var/charge_time = 1 MINUTES //How long does it take to gain a new charge
+	var/current_cooldown //How long until we gain our next charge
+
+/obj/item/card/emag/Initialize(mapload)
+	. = ..()
+	consumer_types = list(
+		typesof(/obj/machinery/door/airlock),
+		typesof(/obj/machinery/door/window/))
 
 /obj/item/card/emag/attack_self(mob/user) //for traitors with balls of plastitanium
 	if(Adjacent(user))
@@ -61,13 +65,6 @@
 	. = ..()
 	playsound(src, 'sound/items/bikehorn.ogg', 50, TRUE)
 
-/obj/item/card/emag/Initialize(mapload)
-	. = ..()
-	type_blacklist = list(typesof(/obj/machinery/door/airlock), typesof(/obj/machinery/door/window/)) //list of all typepaths that require a specialized emag to hack.
-
-/obj/item/card/emag/attack()
-	return
-
 /obj/item/card/emag/afterattack(atom/target, mob/user, proximity)
 	. = ..()
 	var/atom/A = target
@@ -81,7 +78,14 @@
 /obj/item/card/emag/proc/use_charge(mob/user)
 	charges --
 	to_chat(user, span_notice("You use [src]. It now has [charges] charges remaining."))
-	addtimer(CALLBACK(src, .proc/recharge), charge_time, TIMER_UNIQUE)
+	current_cooldown = addtimer(CALLBACK(src, .proc/recharge), charge_time, TIMER_UNIQUE | TIMER_STOPPABLE)
+
+/obj/item/card/emag/proc/can_emag(atom/target, mob/user)
+	for (var/list/subtypelist in consumer_types)
+		if((target.type in subtypelist) && charges <= 0)
+			to_chat(user, span_warning("[src] is out of charges, give it <b>[timeleft(current_cooldown) * 0.1] seconds </b> to recharge!"))
+			return FALSE
+	return TRUE
 
 /obj/item/card/emag/proc/recharge(mob/user)
 	charges = min(charges+1, max_charges)
@@ -90,9 +94,10 @@
 /obj/item/card/emag/examine(mob/user)
 	. = ..()
 	. += span_notice("It has [charges] charges remaining.")
-	if (length(charge_timers))
-		. += "[span_notice("<b>A small display on the back reads:")]</b>"
-	for (var/i in 1 to length(charge_timers))
-		var/timeleft = timeleft(charge_timers[i])
-		var/loadingbar = num2loadingbar(timeleft/charge_time)
-		. += span_notice("<b>CHARGE #[i]: [loadingbar] ([timeleft*0.1]s)</b>")
+	. += "[span_notice("<b>A small display on the back reads:")]</b>"
+	var/timeleft = current_cooldown != TIMER_ID_NULL ? timeleft(current_cooldown) : 0
+	var/loadingbar = num2loadingbar(timeleft/charge_time)
+	if(charges == max_charges)
+		. += span_notice("<b> All [charges] charges are ready for use!</b>")
+	else
+		. += span_notice("<b>[loadingbar] : [timeleft*0.1]s </b> Until the next charge.")

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -149,8 +149,8 @@
 			new /obj/item/ammo_box/magazine/m12g(src) // 2 tc
 			new /obj/item/grenade/c4 (src) // 1 tc
 			new /obj/item/grenade/c4 (src) // 1 tc
-			new /obj/item/card/emag(src) // 4 tc
-			new /obj/item/card/emag/doorjack(src) // 3 tc
+			new /obj/item/grenade/c4 (src) // 1 tc
+			new /obj/item/card/emag(src) // 6 tc
 
 /obj/item/storage/box/syndicate/bundle_b/PopulateContents()
 	switch (pickweight(list(

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1400,9 +1400,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/device_tools/emag
 	name = "Cryptographic Sequencer"
 	desc = "The cryptographic sequencer, electromagnetic card, or emag, is a small card that unlocks hidden functions \
-			in electronic devices, subverts intended functions, and easily breaks security mechanisms. Cannot be used to open airlocks."
+			in electronic devices, subverts intended functions, and easily breaks security mechanisms, including airlocks."
 	item = /obj/item/card/emag
-	cost = 4
+	cost = 6
 
 /datum/uplink_item/device_tools/syndie_jaws_of_life
 	name = "Syndicate Jaws of Life"
@@ -1411,13 +1411,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/crowbar/power/syndicate
 	cost = 4
 	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
-
-/datum/uplink_item/device_tools/doorjack
-	name = "Airlock Authentication Override Card"
-	desc = "A specialized cryptographic sequencer specifically designed to override station airlock access codes. \
-			After hacking a certain number of airlocks, the device will require some time to recharge."
-	item = /obj/item/card/emag/doorjack
-	cost = 3
 
 /datum/uplink_item/device_tools/fakenucleardisk
 	name = "Decoy Nuclear Authentication Disk"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Merges the Doorjack and the Emag into a single 6 tc traitor item.
The new emag can freely hack everything it could, but similarly to the doorjack it now costs charges to specifically hack airlocks.
It has 3 charges and recharges 1 every minute.
## Why It's Good For The Game

Requested.

## Changelog
:cl:
balance: The Doorjack and the Emag have been merged into the old Emag.
balance: Emag cost 4 TC -> 6 TC, can now hack airlocks at the price of rechargeable charges (3 max).
del: The Doorjack no longer exists.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
