### PR TITLE
Makes wallets work (again)

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -77,7 +77,8 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/wearing_human = loc
 		if(wearing_human.wear_id == src)
-			wearing_human.sec_hud_set_ID()
+			wearing_human.sec_hud_set_ID() //sets the sechud icon
+			front_id = (locate(/obj/item/card/id) in contents) //picks first id in the wallet as the appearance of it
 
 	update_label()
 	update_appearance(UPDATE_ICON)


### PR DESCRIPTION
##About The Pull Request
I seriously disliked that the first ID that shows up in the wallet always is the highest ranking ID, in my opinion it should be able to physically hide it and just make secHUDs see if someone has higher access than they have on the card, here is an example of how it works now.
![image](https://user-images.githubusercontent.com/53384660/172202996-1931cf71-3fd8-4244-9b0a-3ea43a08e506.png)


##Why It's Good For The Game
Wallets once more have some more use among people that want to hide their id from collegues, it still won't escape from sight of security though.

Changelog
🆑
qol: The order you put IDs into the wallets matters again. It won't hide your secHUD icon though!
/🆑