### PR TITLE
Fix and Buff Infiltrator Kit.

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -256,15 +256,16 @@
 /obj/item/storage/toolbox/infiltrator/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_combined_w_class = 20
 	STR.max_items = 10
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.set_holdable(list(
-		/obj/item/clothing/head/helmet/infiltrator,
-		/obj/item/clothing/suit/armor/vest/infiltrator,
-		/obj/item/clothing/under/syndicate/bloodred,
-		/obj/item/clothing/gloves/color/infiltrator,
-		/obj/item/clothing/mask/infiltrator,
-		/obj/item/clothing/shoes/combat/sneakboots,
+		/obj/item/clothing/head/,
+		/obj/item/clothing/suit/,
+		/obj/item/clothing/under/,
+		/obj/item/clothing/gloves/,
+		/obj/item/clothing/mask/,
+		/obj/item/clothing/shoes/,
 		/obj/item/gun/ballistic/automatic/pistol,
 		/obj/item/gun/ballistic/revolver,
 		/obj/item/ammo_box

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -260,12 +260,12 @@
 	STR.max_items = 10
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.set_holdable(list(
-		/obj/item/clothing/head/,
-		/obj/item/clothing/suit/,
-		/obj/item/clothing/under/,
-		/obj/item/clothing/gloves/,
-		/obj/item/clothing/mask/,
-		/obj/item/clothing/shoes/,
+		/obj/item/clothing/head,
+		/obj/item/clothing/suit,
+		/obj/item/clothing/under,
+		/obj/item/clothing/gloves,
+		/obj/item/clothing/mask,
+		/obj/item/clothing/shoes,
 		/obj/item/gun/ballistic/automatic/pistol,
 		/obj/item/gun/ballistic/revolver,
 		/obj/item/ammo_box

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -256,7 +256,7 @@
 /obj/item/storage/toolbox/infiltrator/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_combined_w_class = 20
+	STR.max_combined_w_class = 22
 	STR.max_items = 10
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.set_holdable(list(

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -259,6 +259,7 @@
 	STR.max_combined_w_class = 22
 	STR.max_items = 10
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.allow_big_nesting = TRUE //otherwise it will not hold normal sized boots/fedoras.
 	STR.set_holdable(list(
 		/obj/item/clothing/head,
 		/obj/item/clothing/suit,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases the capacity of the case so you can fit a speed loader or 2 with your revolver even when the case is full of clothes. This also means that you can now actually fit all the infiltrator clothes back in the case after you've taken them out, because you couldn't before, because reasons.

## Why It's Good For The Game

The infiltrator kit's purpose is to let you do nefarious, awful, sordid, devilish deeds in your very valid looking suit and swap out of it when needed with the crew none the wiser. Capacity issues hinder this. Letting you hold your old clothes in the case while you're in the suit is only fair, considering it costs 6 tc and the smuggler's satchel manages storage better for a fraction of the cost.

## Changelog
:cl:
fix: You can fit the entire infiltrator outfit into the case now, damnit.
balance: You can also fit non infiltrator clothes with a weight of normal or lower.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
