### PR TITLE
Fix Large Grenades, Minor Rebalance of Regular Grenades.

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -6,14 +6,17 @@
 	w_class = WEIGHT_CLASS_SMALL
 	force = 2
 	var/stage = GRENADE_EMPTY
-	var/list/obj/item/reagent_containers/glass/beakers = list()
-	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle)
+	var/list/obj/item/reagent_containers/beakers = list()
+	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/beaker,
+								/obj/item/reagent_containers/glass/bottle,
+								/obj/item/reagent_containers/food/condiment,
+								/obj/item/reagent_containers/food/drinks/)
 	var/list/banned_containers = list(/obj/item/reagent_containers/glass/beaker/bluespace) //Containers to exclude from specific grenade subtypes
 	var/affected_area = 3
 	var/ignition_temp = 10 // The amount of heat added to the reagents when this grenade goes off.
 	var/threatscale = 1 // Used by advanced grenades to make them slightly more worthy.
 	var/no_splash = FALSE //If the grenade deletes even if it has no reagents to splash with. Used for slime core reactions.
-	var/casedesc = "This basic model accepts both beakers and bottles. It heats contents by 10 K upon ignition." // Appears when examining empty casings.
+	var/casedesc = "This basic model accepts both beakers and bottles, as well as more rudimentary containers if necessary. It heats contents by 10 K upon ignition." // Appears when examining empty casings.
 	var/obj/item/assembly/prox_sensor/landminemode = null
 
 /obj/item/grenade/chem_grenade/ComponentInitialize()
@@ -32,9 +35,9 @@
 	if(user.can_see_reagents())
 		if(beakers.len)
 			. += span_notice("You scan the grenade and detect the following reagents:")
-			for(var/obj/item/reagent_containers/glass/G in beakers)
-				for(var/datum/reagent/R in G.reagents.reagent_list)
-					. += span_notice("[R.volume] units of [R.name] in the [G.name].")
+			for(var/obj/item/reagent_containers/B in beakers)
+				for(var/datum/reagent/R in B.reagents.reagent_list)
+					. += span_notice("[R.volume] units of [R.name] in the [B.name].")
 			if(beakers.len == 1)
 				. += span_notice("You detect no second beaker in the grenade.")
 		else
@@ -43,8 +46,8 @@
 		if(beakers.len == 2 && beakers[1].name == beakers[2].name)
 			. += span_notice("You see two [beakers[1].name]s inside the grenade.")
 		else
-			for(var/obj/item/reagent_containers/glass/G in beakers)
-				. += span_notice("You see a [G.name] inside the grenade.")
+			for(var/obj/item/reagent_containers/B in beakers)
+				. += span_notice("You see a [B.name] inside the grenade.")
 
 /obj/item/grenade/chem_grenade/attack_self(mob/user)
 	if(stage == GRENADE_READY && !active)
@@ -180,8 +183,8 @@
 
 	. = ..()
 	var/list/datum/reagents/reactants = list()
-	for(var/obj/item/reagent_containers/glass/G in beakers)
-		reactants += G.reagents
+	for(var/obj/item/reagent_containers/B in beakers)
+		reactants += B.reagents
 
 	var/turf/detonation_turf = get_turf(src)
 
@@ -219,8 +222,9 @@
 
 	for(var/obj/item/slime_extract/S in beakers)
 		if(S.Uses)
-			for(var/obj/item/reagent_containers/glass/G in beakers)
-				G.reagents.trans_to(S, G.reagents.total_volume)
+			for(var/obj/item/reagent_containers/B in beakers)
+				if(!istype(B, /obj/item/slime_extract))
+					B.reagents.trans_to(S, B.reagents.total_volume)
 
 			//If there is still a core (sometimes it's used up)
 			//and there are reagents left, behave normally,
@@ -228,8 +232,9 @@
 
 			if(S)
 				if(S.reagents && S.reagents.total_volume)
-					for(var/obj/item/reagent_containers/glass/G in beakers)
-						S.reagents.trans_to(G, S.reagents.total_volume)
+					for(var/obj/item/reagent_containers/B in beakers)
+						if(!istype(B, /obj/item/slime_extract))
+							S.reagents.trans_to(B, S.reagents.total_volume)
 				else
 					S.forceMove(get_turf(src))
 					no_splash = TRUE

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -35,7 +35,7 @@
 	if(user.can_see_reagents())
 		if(beakers.len)
 			. += span_notice("You scan the grenade and detect the following reagents:")
-			for(var/obj/item/reagent_containers/B in beakers)
+			for(var/obj/item/reagent_containers/B as anything in beakers)
 				for(var/datum/reagent/R in B.reagents.reagent_list)
 					. += span_notice("[R.volume] units of [R.name] in the [B.name].")
 			if(beakers.len == 1)
@@ -46,7 +46,7 @@
 		if(beakers.len == 2 && beakers[1].name == beakers[2].name)
 			. += span_notice("You see two [beakers[1].name]s inside the grenade.")
 		else
-			for(var/obj/item/reagent_containers/B in beakers)
+			for(var/obj/item/reagent_containers/B as anything in beakers)
 				. += span_notice("You see a [B.name] inside the grenade.")
 
 /obj/item/grenade/chem_grenade/attack_self(mob/user)
@@ -183,7 +183,7 @@
 
 	. = ..()
 	var/list/datum/reagents/reactants = list()
-	for(var/obj/item/reagent_containers/B in beakers)
+	for(var/obj/item/reagent_containers/B as anything in beakers)
 		reactants += B.reagents
 
 	var/turf/detonation_turf = get_turf(src)
@@ -222,7 +222,7 @@
 
 	for(var/obj/item/slime_extract/S in beakers)
 		if(S.Uses)
-			for(var/obj/item/reagent_containers/B in beakers)
+			for(var/obj/item/reagent_containers/B as anything in beakers)
 				if(!istype(B, /obj/item/slime_extract))
 					B.reagents.trans_to(S, B.reagents.total_volume)
 
@@ -232,7 +232,7 @@
 
 			if(S)
 				if(S.reagents && S.reagents.total_volume)
-					for(var/obj/item/reagent_containers/B in beakers)
+					for(var/obj/item/reagent_containers/B as anything in beakers)
 						if(!istype(B, /obj/item/slime_extract))
 							S.reagents.trans_to(B, S.reagents.total_volume)
 				else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows large grenades to work properly with non standard containers again (i.e. ones that aren't the 30u glass bottles or the various beakers you can obtain). This also allows you to use more ghetto reagent containers in regular chemical grenades such as cans of cola, plastic bottles or even trophy cups.

## Why It's Good For The Game

I don't think the regular chemical grenade was meant to fit non standard containers, but the large one was. It makes more sense for the regular one to be able to fit ghetto alternatives as it is the large casing that is locked behind tech and more likely to be used by chemists. Only serious balance implication I can think of is it being a bit easier to make ghetto sonic powder grenades, otherwise it's mostly QoL.

## Changelog
:cl:
balance: You can now load booze bottles, plastic bottles, soda cans etc in normal grenades.
fix: Alternate reagent containers now work in large grenades again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
