### PR TITLE
Nerf Smoking Lung Damage and Addiction

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -158,7 +158,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	/// Should we smoke all of the chems in the cig before it runs out. Splits each puff to take a portion of the overall chems so by the end you'll always have consumed all of the chems inside.
 	var/smoke_all = FALSE
 	/// How much damage this deals to the lungs per drag.
-	var/lung_harm = 1
+	var/lung_harm = 0.8
 
 
 /obj/item/clothing/mask/cigarette/Initialize()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -70,7 +70,7 @@
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	ph = 8
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	addiction_types = list(/datum/addiction/nicotine = 18) // 7.2 per 2 seconds
+	addiction_types = list(/datum/addiction/nicotine = 10) // 4 per 2 seconds
 
 	//Nicotine is used as a pesticide IRL.
 /datum/reagent/drug/nicotine/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You now receive 0.8 lung damage every 10 seconds instead of 1, because of the way that organs heal expect around half as much lung damage per cigarette as before. Nicotine addiction point gain has been nearly halved, now it takes 2 Space brand cigarettes to addict you as opposed to one.

## Why It's Good For The Game

With how lung damage works, it meant that before, every time you smoke a cigarette, your chat will get spammed with messages notifying you of lung damage being received and then healed. Smoking about 7 cigarettes completely destroying your lungs is funny but a bit overtuned. The real nightmare was addiction, it was less (but still) an issue for brands like robust and carp classic, but seriously affected were the cigarettes that forced you to smoke all reagents in the cigarette. Notably this caused Space Cigarettes and Syndicate Smokes to addict you with 1 ciggie. By smoking cigarettes back to back you can still get noticeable lung damage and addiction, it's just less egregious now.

## Changelog
:cl:
balance: Cigarettes and cigars now take twice as long to get addicted to and feel the effects of lung damage from them.
/:cl: