### PR TITLE
Mechs can't bump closed blast doors open anymore

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -149,6 +149,9 @@
 	else
 		return ..()
 
+/obj/machinery/door/poddoor/shutters/bumpopen()
+	return
+
 //"BLAST" doors are obviously stronger than regular doors when it comes to BLASTS.
 /obj/machinery/door/poddoor/ex_act(severity, target)
 	if(severity <= EXPLODE_LIGHT)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -36,12 +36,20 @@
 
 	if(panel_open)
 		if(W.tool_behaviour == TOOL_MULTITOOL && deconstruction == BLASTDOOR_FINISHED)
+			if (density)
+				balloon_alert(user, "open the door first!")
+				return
+
 			var/change_id = input("Set the shutters/blast door/blast door controllers ID. It must be a number between 1 and 100.", "ID", id) as num|null
 			if(change_id)
 				id = clamp(round(change_id, 1), 1, 100)
 				to_chat(user, span_notice("You change the ID to [id]."))
 
 		else if(W.tool_behaviour == TOOL_CROWBAR && deconstruction == BLASTDOOR_FINISHED)
+			if (density)
+				balloon_alert(user, "open the door first!")
+				return
+
 			to_chat(user, span_notice("You start to remove the airlock electronics."))
 			if(do_after(user, 10 SECONDS, target = src))
 				new /obj/item/electronics/airlock(loc)
@@ -49,6 +57,10 @@
 				deconstruction = BLASTDOOR_NEEDS_ELECTRONICS
 
 		else if(W.tool_behaviour == TOOL_WIRECUTTER && deconstruction == BLASTDOOR_NEEDS_ELECTRONICS)
+			if (density)
+				balloon_alert(user, "open the door first!")
+				return
+
 			to_chat(user, span_notice("You start to remove the internal cables."))
 			if(do_after(user, 10 SECONDS, target = src))
 				var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
@@ -57,6 +69,10 @@
 				deconstruction = BLASTDOOR_NEEDS_WIRES
 
 		else if(W.tool_behaviour == TOOL_WELDER && deconstruction == BLASTDOOR_NEEDS_WIRES)
+			if (density)
+				balloon_alert(user, "open the door first!")
+				return
+
 			if(!W.tool_start_check(user, amount=0))
 				return
 
@@ -149,7 +165,7 @@
 	else
 		return ..()
 
-/obj/machinery/door/poddoor/shutters/bumpopen()
+/obj/machinery/door/poddoor/bumpopen()
 	return
 
 //"BLAST" doors are obviously stronger than regular doors when it comes to BLASTS.

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -51,6 +51,3 @@
 /obj/machinery/door/poddoor/shutters/window/preopen
 	icon_state = "open"
 	density = FALSE
-
-/obj/machinery/door/poddoor/shutters/bumpopen()
-	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes mechs being able to bump open blast doors.

## Why It's Good For The Game

Fixes #6 

## Changelog
:cl:
fix: Mechs can't walk into blast doors anymore to open them regardless of state.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
