### PR TITLE
chem dispenser silver 

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -56,6 +56,7 @@
 		/datum/reagent/potassium,
 		/datum/reagent/uranium/radium,
 		/datum/reagent/silicon,
+		/datum/reagent/silver,
 		/datum/reagent/sodium,
 		/datum/reagent/stable_plasma,
 		/datum/reagent/consumable/sugar,


### PR DESCRIPTION

## Why It's Good For The Game

no more grinding silver which was pointless since you can access enough of it roundstart to last for the whole game???

## Changelog
:cl:
add: adds back silver to the chem dispenser 
/:cl:

