### PR TITLE
Removes knockdown from stunbaton and all its children

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -242,7 +242,6 @@
 	L.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
-	addtimer(CALLBACK(src, .proc/apply_stun_effect_end, L), apply_stun_delay)
 
 	if(user)
 		L.lastattacker = user.real_name
@@ -259,17 +258,6 @@
 	addtimer(TRAIT_CALLBACK_REMOVE(L, TRAIT_IWASBATONED, STATUS_EFFECT_TRAIT), attack_cooldown)
 
 	return 1
-
-/// After the initial stun period, we check to see if the target needs to have the stun applied.
-/obj/item/melee/baton/proc/apply_stun_effect_end(mob/living/target)
-	var/trait_check = HAS_TRAIT(target, TRAIT_STUNRESISTANCE) //var since we check it in out to_chat as well as determine stun duration
-	if(!target.IsKnockdown())
-		to_chat(target, span_warning("Your muscles seize, making you collapse[trait_check ? ", but your body quickly recovers..." : "!"]"))
-
-	if(trait_check)
-		target.Knockdown(stun_time * 0.1)
-	else
-		target.Knockdown(stun_time)
 
 /obj/item/melee/baton/emp_act(severity)
 	. = ..()

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -536,6 +536,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	switch (mode)
 		if(BATON_STUN)
 			..()
+			addtimer(CALLBACK(src, .proc/apply_stun_effect_end, L), apply_stun_delay)
 		if(BATON_SLEEP)
 			SleepAttack(L,user)
 		if(BATON_CUFF)
@@ -544,7 +545,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 			ProbeAttack(L,user)
 	return
 
-/obj/item/melee/baton/abductor/apply_stun_effect_end(mob/living/target)
+/obj/item/melee/baton/abductor/proc/apply_stun_effect_end(mob/living/target)
 	StunAttack(target)
 
 /obj/item/melee/baton/abductor/proc/StunAttack(mob/living/L)


### PR DESCRIPTION
## About The Pull Request
Removes knockdown from stunbatons and its children (stunprod, teleprod)
Abductor's baton and telebaton are unchanged

## Why It's Good For The Game
The stunbatons are too strong and I have hosts blessing in this regard

## Changelog
🆑
balance: Stunbatons, stunprods and teleprods no longer cause knockdown.
/🆑