### PR TITLE
Fixed observe during initialization not observing.

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -142,6 +142,17 @@
 			ready = tready
 		//if it's post initialisation and they're trying to observe we do the needful
 		if(!SSticker.current_state < GAME_STATE_PREGAME && tready == PLAYER_READY_TO_OBSERVE)
+			var/less_input_message
+			if(SSlag_switch.measures[DISABLE_DEAD_KEYLOOP])
+				less_input_message = " - Notice: Observer freelook is currently disabled."
+			var/this_is_like_playing_right = tgui_alert(usr, "Are you sure you wish to observe? You will not be able to play this round![less_input_message]","Player Setup",list("Yes","No"))
+
+			if(QDELETED(src) || !src.client || this_is_like_playing_right != "Yes")
+				ready = PLAYER_NOT_READY
+				src << browse(null, "window=playersetup") //closes the player setup window
+				new_player_panel()
+				return
+
 			ready = tready
 			make_me_an_observer()
 			return
@@ -212,17 +223,6 @@
 /mob/dead/new_player/proc/make_me_an_observer()
 	if(QDELETED(src) || !src.client)
 		ready = PLAYER_NOT_READY
-		return FALSE
-
-	var/less_input_message
-	if(SSlag_switch.measures[DISABLE_DEAD_KEYLOOP])
-		less_input_message = " - Notice: Observer freelook is currently disabled."
-	var/this_is_like_playing_right = tgui_alert(usr, "Are you sure you wish to observe? You will not be able to play this round![less_input_message]","Player Setup",list("Yes","No"))
-
-	if(QDELETED(src) || !src.client || this_is_like_playing_right != "Yes")
-		ready = PLAYER_NOT_READY
-		src << browse(null, "window=playersetup") //closes the player setup window
-		new_player_panel()
 		return FALSE
 
 	var/mob/dead/observer/observer = new()


### PR DESCRIPTION
## About The Pull Request
Fixes an old bug that made selecting observe during initialization not observe you automatically like it was supposed to.

## Changelog
:cl:
fix: Selecting observe in lobby while the game is initializing now works properly.
/:cl: