### PR TITLE
Fix east stare on latejoin

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -115,7 +115,6 @@
 	if(!length(buckled_mobs))
 		RegisterSignal(src, COMSIG_MOVABLE_SET_ANCHORED, .proc/on_set_anchored)
 	M.set_buckled(src)
-	M.setDir(dir)
 	buckled_mobs |= M
 	M.throw_alert("buckled", /atom/movable/screen/alert/buckled)
 	M.set_glide_size(glide_size)
@@ -124,6 +123,7 @@
 		M.Move(loc)
 	else if (!check_loc && M.loc != loc)
 		M.forceMove(loc)
+	M.setDir(dir)
 
 	post_buckle_mob(M)
 


### PR DESCRIPTION
## About The Pull Request
You will no longer stare east when latejoining

## Why It's Good For The Game
muh immershioon

## Changelog
:cl:
fix: latejoin buckling sets your facing direction correctly.
/:cl:
