### PR TITLE
Removes poplimit from noslips and reduces cost of nukie noslips to 2 TC

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1269,7 +1269,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			They do not work on heavily lubricated surfaces."
 	item = /obj/item/clothing/shoes/chameleon/noslip
 	cost = 2
-	purchasable_from = ~(UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/stealthy_tools/jammer
 	name = "Radio Jammer"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1269,13 +1269,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			They do not work on heavily lubricated surfaces."
 	item = /obj/item/clothing/shoes/chameleon/noslip
 	cost = 2
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
-	player_minimum = 20
-
-/datum/uplink_item/stealthy_tools/syndigaloshes/nuke
-	item = /obj/item/clothing/shoes/chameleon/noslip
-	cost = 4
-	purchasable_from = UPLINK_NUKE_OPS
+	purchasable_from = ~(UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/stealthy_tools/jammer
 	name = "Radio Jammer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It's on the tin

## Why It's Good For The Game

Its pretty stupid for noslips to be limited now as slipping is less dangerous than it used to be, 4tc cost for nukies is also stupid 

## Changelog
:cl:

balance: Removed poplimit from noslips, reduces their price to 2 for nukies
code: removed nukie noslip subtype

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
