### PR TITLE
Removes mode check from dead/observer lists.

### DIFF
--- a/code/modules/mob/mob_lists.dm
+++ b/code/modules/mob/mob_lists.dm
@@ -25,7 +25,7 @@
 ///Adds a mob reference to the list of all suicided mobs
 /mob/proc/add_to_mob_suicide_list()
 	GLOB.suicided_mob_list += src
-	
+
 ///Removes a mob references from the list of all suicided mobs
 /mob/proc/remove_from_mob_suicide_list()
 	GLOB.suicided_mob_list -= src
@@ -53,8 +53,6 @@
 		GLOB.keyloop_list |= src
 	else if(stat != DEAD || !SSlag_switch?.measures[DISABLE_DEAD_KEYLOOP])
 		GLOB.keyloop_list |= src
-	if(!SSticker?.mode)
-		return
 	if(stat == DEAD)
 		add_to_current_dead_players()
 	else
@@ -65,8 +63,6 @@
 	SHOULD_CALL_PARENT(TRUE)
 	GLOB.player_list -= src
 	GLOB.keyloop_list -= src
-	if(!SSticker?.mode)
-		return
 	if(stat == DEAD)
 		remove_from_current_dead_players()
 	else
@@ -75,13 +71,9 @@
 
 ///Adds the cliented mob reference to either the list of dead player-mobs or to the list of observers, depending on how they joined the game.
 /mob/proc/add_to_current_dead_players()
-	if(!SSticker?.mode)
-		return
 	GLOB.dead_player_list |= src
 
 /mob/dead/observer/add_to_current_dead_players()
-	if(!SSticker?.mode)
-		return
 	if(started_as_observer)
 		GLOB.current_observers_list |= src
 		return
@@ -92,13 +84,9 @@
 
 ///Removes the mob reference from either the list of dead player-mobs or from the list of observers, depending on how they joined the game.
 /mob/proc/remove_from_current_dead_players()
-	if(!SSticker?.mode)
-		return
 	GLOB.dead_player_list -= src
 
 /mob/dead/observer/remove_from_current_dead_players()
-	if(!SSticker?.mode)
-		return
 	if(started_as_observer)
 		GLOB.current_observers_list -= src
 		return
@@ -107,16 +95,12 @@
 
 ///Adds the cliented mob reference to the list of living player-mobs. If the mob is an antag, it adds it to the list of living antag player-mobs.
 /mob/proc/add_to_current_living_players()
-	if(!SSticker?.mode)
-		return
 	GLOB.alive_player_list |= src
 	if(mind && (mind.special_role || length(mind.antag_datums)))
 		add_to_current_living_antags()
 
 ///Removes the mob reference from the list of living player-mobs. If the mob is an antag, it removes it from the list of living antag player-mobs.
 /mob/proc/remove_from_current_living_players()
-	if(!SSticker?.mode)
-		return
 	GLOB.alive_player_list -= src
 	if(LAZYLEN(mind?.antag_datums))
 		remove_from_current_living_antags()
@@ -124,12 +108,8 @@
 
 ///Adds the cliented mob reference to the list of living antag player-mobs.
 /mob/proc/add_to_current_living_antags()
-	if(!SSticker?.mode)
-		return
 	GLOB.current_living_antags |= src
 
 ///Removes the mob reference from the list of living antag player-mobs.
 /mob/proc/remove_from_current_living_antags()
-	if(!SSticker?.mode)
-		return
 	GLOB.current_living_antags -= src


### PR DESCRIPTION
So, if you observed before the game actually starts you didn't get added to the observer list which means you aren't considered a candidate for ghost role midround rulesets. This fixes that.