### PR TITLE
Adds a config to toggle wound application

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -367,3 +367,5 @@
 	integer = FALSE // It is in hours, but just in case one wants to specify minutes.
 
 /datum/config_entry/flag/sdql_spells
+
+/datum/config_entry/flag/enable_wounds

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -107,6 +107,9 @@
  * * smited- If this is a smite, we don't care about this wound for stat tracking purposes (not yet implemented)
  */
 /datum/wound/proc/apply_wound(obj/item/bodypart/L, silent = FALSE, datum/wound/old_wound = null, smited = FALSE)
+	if(!CONFIG_GET(flag/enable_wounds))
+		return
+
 	if(!istype(L) || !L.owner || !(L.body_zone in viable_zones) || !L.is_organic_limb() || HAS_TRAIT(L.owner, TRAIT_NEVER_WOUNDED))
 		qdel(src)
 		return

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -563,3 +563,6 @@ MAXFINE 2000
 ## Warning: SDQL is a powerful tool and can break many things or expose security sensitive information.
 ## Giving players access to it has major security concerns, be careful and deliberate when using this feature.
 #SDQL_SPELLS
+
+## Uncomment to enable wounds
+#ENABLE_WOUNDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I tried to sleep. But I couldn't.  
I just couldn't rest knowing that tomorrow I might have to once again spend 10+ minutes and countless regenerative meshes after getting hit by 1(one) stray laser shot. Yes, this is the cumulative product of over a year of ided frustrations.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We don't like wounds, not in their current form, that much is clear. What is not clear is what would allow to make them fit into an LRP playstyle and recent efforts have shown that it is no simple undertaking to overhaul them.  
This at least allows us to not have to deal with wounds while we take our time to decide their fate.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Thebleh
config: Added a config setting to toggle wound application. Default off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
