### PR TITLE
Pipe Amending

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -118,6 +118,7 @@
 #define RCD_UPGRADE_FURNISHING (1<<3)
 
 #define RPD_UPGRADE_UNWRENCH (1<<0)
+#define RPD_UPGRADE_AMEND (1<<1)
 
 #define RCD_WINDOW_FULLTILE "full tile"
 #define RCD_WINDOW_DIRECTIONAL "directional"

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -167,7 +167,9 @@
 	return
 
 /obj/machinery/atmospherics/pipe/addMember(obj/machinery/atmospherics/considered_device)
-	parent.addMember(considered_device, src)
+	// This will be added when rebuild creates a pipeline if not available
+	if(parent)
+		parent.addMember(considered_device, src)
 
 /obj/machinery/atmospherics/components/addMember(obj/machinery/atmospherics/considered_device)
 	var/datum/pipeline/device_pipeline = returnPipenet(considered_device)

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -11,6 +11,7 @@
 	initialize_directions = EAST|NORTH|WEST
 
 	device_type = TRINARY
+	amendable = TRUE
 
 	construction_type = /obj/item/pipe/trinary
 	pipe_state = "he_manifold"
@@ -47,3 +48,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer4
 	piping_layer = 4
 	icon_state = "manifold-4"
+
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/createAmend(turf/T, direction)
+	return new /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/(T) 

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -50,4 +50,4 @@
 	icon_state = "manifold-4"
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/createAmend(turf/T, direction)
-	return new /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/(T) 
+	return new /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w(T) 

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
@@ -10,6 +10,7 @@
 	pipe_flags = PIPING_CARDINAL_AUTONORMALIZE
 
 	device_type = BINARY
+	amendable = TRUE
 
 	construction_type = /obj/item/pipe/binary/bendable
 	pipe_state = "he"
@@ -36,3 +37,8 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4
 	piping_layer = 4
 	icon_state = "pipe11-4"
+
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/createAmend(turf/T, direction)
+	var/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/new_pipe = new /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/(T)
+	new_pipe.setDir((initialize_directions | direction) ^ 15)
+	return new_pipe

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -47,4 +47,4 @@
 	update_layer()
 
 /obj/machinery/atmospherics/pipe/manifold/createAmend(turf/T, direction)
-	return new /obj/machinery/atmospherics/pipe/manifold4w/(T) 
+	return new /obj/machinery/atmospherics/pipe/manifold4w(T)

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -11,6 +11,7 @@
 	initialize_directions = EAST|NORTH|WEST
 
 	device_type = TRINARY
+	amendable = TRUE
 
 	construction_type = /obj/item/pipe/trinary
 	pipe_state = "manifold"
@@ -44,3 +45,6 @@
 		if(nodes[i])
 			. += getpipeimage(icon, "pipe-[piping_layer]", get_dir(src, nodes[i]))
 	update_layer()
+
+/obj/machinery/atmospherics/pipe/manifold/createAmend(turf/T, direction)
+	return new /obj/machinery/atmospherics/pipe/manifold4w/(T) 

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -92,14 +92,14 @@
 
 		// Don't be already connected there
 		if(GetInitDirections() & direction)
-			to_chat(user, "<span class='warning'>There is already a connection in that direction!</span>")
+			to_chat(user, span_warning("There is already a connection in that direction!"))
 			return FALSE
 		// Don't overlap other pipes
 		for(var/obj/machinery/atmospherics/other in loc)
 			if((other.piping_layer != piping_layer) && !((other.pipe_flags | pipe_flags) & PIPING_ALL_LAYER)) // Don't continue if either pipe goes across all layers
 				continue
 			if(other.GetInitDirections() & direction) // New connection is occupied by other
-				to_chat(user, "<span class='warning'>There is already a pipe at that location!</span>")
+				to_chat(user, span_warning("There is already a pipe at that location!"))
 				return FALSE
 
 		var/turf/T = loc

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -113,20 +113,30 @@
 
 		var/turf/T = loc
 
-		// Remove existing pipe
+		// Remove from adjacent pipes
+		for(var/obj/machinery/atmospherics/other in nodes)
+			var/index = other.nodes.Find(src)
+			other.nodes[index] = null
+		
+		// Don't spill or lose gas
 		flags_1 |= NODECONSTRUCT_1
 		parent.air.volume -= volume
 		parent.members -= src
+		// Keep the old pipenet (bit hacky)
+		parent = null // Destroy() won't qdel the pipenet
+		device_type = 0 // Destroy() won't nullifyNodes()  (we do that manually earlier)
+
 		deconstruct()
 
 		// Create new pipe
 		var/obj/machinery/atmospherics/pipe/new_pipe = createAmend(T, direction)
 		new_pipe.name = name
-		transfer_fingerprints_to(new_pipe)
 		new_pipe.SetInitDirections()
 		new_pipe.on_construction(color, piping_layer)
+		// Let's keep spraycan and fingerprints too
 		new_pipe.atom_colours = atom_colours
 		new_pipe.update_atom_colour()
+		transfer_fingerprints_to(new_pipe)
 		
 		// Feedback
 		W.play_tool_sound(new_pipe)
@@ -137,7 +147,6 @@
 	return TRUE
 
 /obj/machinery/atmospherics/pipe/proc/createAmend(turf/T, direction)
-	say("ASSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS.")
 
 /obj/machinery/atmospherics/pipe/returnPipenet()
 	return parent

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -1,4 +1,4 @@
-#define ARROW_ICON(x) image(icon = 'icons/testing/turf_analysis.dmi', icon_state = "red_arrow", dir = x)
+#define ARROW_ICON(x) "[x]" = image(icon = 'icons/testing/turf_analysis.dmi', icon_state = "red_arrow", dir = x)
 
 /obj/machinery/atmospherics/pipe
 	damage_deflection = 12
@@ -19,10 +19,10 @@
 
 	// Lists can't have integer keys
 	var/static/list/radial_options = list(
-		"NORTH" = ARROW_ICON(NORTH),
-		"EAST" = ARROW_ICON(EAST),
-		"SOUTH" = ARROW_ICON(SOUTH),
-		"WEST" = ARROW_ICON(WEST)
+		ARROW_ICON(NORTH),
+		ARROW_ICON(EAST),
+		ARROW_ICON(SOUTH),
+		ARROW_ICON(WEST)
 	)
 
 #undef ARROW_ICON
@@ -88,16 +88,7 @@
 	var/choice = show_radial_menu(user, src, radial_options, require_near = TRUE)
 	if(choice)
 		// Figure out which way we're adding
-		var/direction = 0
-		switch(choice)
-			if("NORTH")
-				direction = NORTH
-			if("EAST")
-				direction = EAST
-			if("SOUTH")
-				direction = SOUTH
-			if("WEST")
-				direction = WEST
+		var/direction = text2num(choice)
 
 		// Don't be already connected there
 		if(GetInitDirections() & direction)

--- a/code/modules/atmospherics/machinery/pipes/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple.dm
@@ -13,6 +13,7 @@
 	pipe_flags = PIPING_CARDINAL_AUTONORMALIZE
 
 	device_type = BINARY
+	amendable = TRUE
 
 	construction_type = /obj/item/pipe/binary/bendable
 	pipe_state = "simple"
@@ -30,3 +31,8 @@
 /obj/machinery/atmospherics/pipe/simple/update_icon_state()
 	icon_state = "pipe[nodes[1] ? "1" : "0"][nodes[2] ? "1" : "0"]-[piping_layer]"
 	return ..()
+
+/obj/machinery/atmospherics/pipe/simple/createAmend(turf/T, direction)
+	var/obj/machinery/atmospherics/pipe/manifold/new_pipe = new /obj/machinery/atmospherics/pipe/manifold/(T)
+	new_pipe.setDir((initialize_directions | direction) ^ 15)
+	return new_pipe

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -103,6 +103,16 @@
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
+/datum/design/rpd_upgrade/amend
+	name = "RPD amending upgrade"
+	desc = "Adds pipe amending functionality to the RPD. Right-click a pipe with the RPD to activate."
+	id = "rpd_upgrade_amend"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 5000, /datum/material/glass = 2500)
+	build_path = /obj/item/rpd_upgrade/amend
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
 /datum/design/rld_mini
 	name = "Mini Rapid Light Device (MRLD)"
 	desc = "A tool that can portable and standing lighting orbs and glowsticks."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1311,6 +1311,7 @@
 		"rcd_upgrade_furnishing",
 		"rcd_upgrade_simple_circuits",
 		"rpd_upgrade_unwrench",
+		"rpd_upgrade_amend",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	channel_tag = list(RADIO_CHANNEL_ENGINEERING)


### PR DESCRIPTION
## About The Pull Request

When one wants to connect to an existing pipe, the only ways to do so are by either having previously planned and added a free node, or removing a pipe and adding a free node. This is a problem when in a multiplayer environment as planning is usually not possible, and removing a pipe will often result in a gas leak. This merge request adds a way to add nodes to existing pipes, without unwrenching the pipe and causing trouble. This is done by rightclicking a pipe with an RPD that has the Amend upgrade, and selecting a direction for a new node from a radial menu. Also works on heat exchange pipes. The upgrade must be researched from the Rapid Construction node, and can be printed in the engineering lathe. Previous RPD rightclick functionality (copying layer and colour of existing pipe) has been replaced (the colour part didn't work anyway).
Additionally, placing multiple connected pipes in a single atmos tick will no longer cause a runtime error.

## Why It's Good For The Game

Makes piping less annoying, especially with multiple people.
Less errors is good.

## Changelog
:cl:
add: RPD Amend upgrade disk, allows an RPD to rightclick atmos pipes to add nodes.
fix: Placing pipes quickly won't runtime.
/:cl: