### PR TITLE
Fixing Reaction Chambers Part 4 Revengeance

### DIFF
--- a/code/datums/components/plumbing/reaction_chamber.dm
+++ b/code/datums/components/plumbing/reaction_chamber.dm
@@ -7,6 +7,12 @@
 	if(!istype(parent, /obj/machinery/plumbing/reaction_chamber))
 		return COMPONENT_INCOMPATIBLE
 
+/datum/component/plumbing/reaction_chamber/can_give(amount, reagent, datum/ductnet/net)
+	. = ..()
+	var/obj/machinery/plumbing/reaction_chamber/reaction_chamber = parent
+	if(!. || !reaction_chamber.emptying || reagents.is_reacting == TRUE)
+		return FALSE
+
 /datum/component/plumbing/reaction_chamber/send_request(dir)
 	var/obj/machinery/plumbing/reaction_chamber/chamber = parent
 	if(chamber.emptying)

--- a/code/datums/components/plumbing/reaction_chamber.dm
+++ b/code/datums/components/plumbing/reaction_chamber.dm
@@ -10,8 +10,7 @@
 /datum/component/plumbing/reaction_chamber/can_give(amount, reagent, datum/ductnet/net)
 	. = ..()
 	var/obj/machinery/plumbing/reaction_chamber/reaction_chamber = parent
-	if(!reaction_chamber.emptying)
-		return FALSE
+	return (. && reaction_chamber.emptying)
 
 /datum/component/plumbing/reaction_chamber/send_request(dir)
 	var/obj/machinery/plumbing/reaction_chamber/chamber = parent

--- a/code/datums/components/plumbing/reaction_chamber.dm
+++ b/code/datums/components/plumbing/reaction_chamber.dm
@@ -10,7 +10,7 @@
 /datum/component/plumbing/reaction_chamber/can_give(amount, reagent, datum/ductnet/net)
 	. = ..()
 	var/obj/machinery/plumbing/reaction_chamber/reaction_chamber = parent
-	if(!. || !reaction_chamber.emptying || reagents.is_reacting == TRUE)
+	if(!reaction_chamber.emptying)
 		return FALSE
 
 /datum/component/plumbing/reaction_chamber/send_request(dir)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -439,28 +439,33 @@
 	var/list/cached_reagents = reagent_list
 	if (!target)
 		return
-	if (!target.reagents || src.total_volume<=0 || !src.get_reagent_amount(reagent))
+
+	var/datum/reagents/holder
+	if(istype(target, /datum/reagents))
+		holder = target
+	else if(target.reagents && total_volume > 0 && get_reagent_amount(reagent))
+		holder = target.reagents
+	else
 		return
 	if(amount < 0)
 		return
 
-	var/datum/reagents/R = target.reagents
-	if(src.get_reagent_amount(reagent)<amount)
-		amount = src.get_reagent_amount(reagent)
-	amount = min(amount, R.maximum_volume-R.total_volume)
+	if(get_reagent_amount(reagent) < amount)
+		amount = get_reagent_amount(reagent)
+	amount = min(round(amount, CHEMICAL_VOLUME_ROUNDING), holder.maximum_volume - holder.total_volume)
 	var/trans_data = null
-	for (var/CR in cached_reagents)
-		var/datum/reagent/current_reagent = CR
+	for (var/looping_through_reagents in cached_reagents)
+		var/datum/reagent/current_reagent = looping_through_reagents
 		if(current_reagent.type == reagent)
 			if(preserve_data)
 				trans_data = current_reagent.data
-			R.add_reagent(current_reagent.type, amount, trans_data, src.chem_temp)
+			holder.add_reagent(current_reagent.type, amount, trans_data, src.chem_temp)
 			remove_reagent(current_reagent.type, amount, 1)
 			break
 
-	src.update_total()
-	R.update_total()
-	R.handle_reactions()
+	update_total()
+	holder.update_total()
+	holder.handle_reactions()
 	return amount
 
 /// Copies the reagents to the target object


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pleaseworkthistimepleaseworkthistimepleaseworkthistimeplease
Re-adds the check for if reaction chamber will give reagents to ductnets, that was removed in fermichem removal.
Fixes https://github.com/AetherStation/AetherStation13/issues/131
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/41806499/182336601-a3c6c58e-6271-4b9c-9aec-e355e237d4af.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Chems will now stop to react in reaction chamber.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
