### PR TITLE
Fire alarms now trigger on -63C instead of -3C

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -125,7 +125,7 @@
 	playsound(src, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 
 /obj/machinery/firealarm/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	return (exposed_temperature > T0C + 200 || exposed_temperature < BODYTEMP_COLD_DAMAGE_LIMIT) && !(obj_flags & EMAGGED) && !machine_stat
+	return (exposed_temperature > T0C + 200 || exposed_temperature < BODYTEMP_COLD_DAMAGE_LIMIT - 60) && !(obj_flags & EMAGGED) && !machine_stat
 
 /obj/machinery/firealarm/atmos_expose(datum/gas_mixture/air, exposed_temperature)
 	if(!detecting)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lowers the fire alarm cold trigger from -3C (internal body temp damage treshold)  to -63C (it doesnt hurt you to stand around at this temp for quite a while if ever). Makes the firelocks much less likely to trigger from breaches. 

Effectively, this change makes breaches a bit more dangerous as they will vent more before the doors close. In huge rooms like main hallways, this will take 5+ minutes, and vent a lot of gas, but not below low pressure, so fine to move around in if you got internals. In small rooms, obviously will be faster but still takes a few minutes.
Does make it possible to make the fire alarms disengage by fixing the atmos "well enough" instead of having to raise temperature to tropical beach level before the fire alarms calm the fuck down.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . beep beep beep beep beep beep beep . . . . . . . . . . . . . . . . . . . . . . . . . . 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Firelocks no longer trigger at -3C, lowered to -63C. Still safe temperature and pressure levels, but will make breaches vent significantly more atmos before the firelocks engage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
