### PR TITLE
Tablet batteries and ID's now properly delete

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -68,7 +68,13 @@
 	kill_program(forced = TRUE)
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(soundloop)
-	QDEL_LIST(all_components)
+	for(var/H in all_components)
+		var/obj/item/computer_hardware/CH = all_components[H]
+		if(CH.holder == src)
+			CH.on_remove(src, deleting = TRUE)
+			CH.holder = null
+			all_components.Remove(CH.device_type)
+			qdel(CH)
 	physical = null
 	return ..()
 
@@ -432,7 +438,7 @@
 		idle_threads.Remove(P)
 	if(looping_sound)
 		soundloop.stop()
-	if(loud && !QDELETED(physical))
+	if(loud)
 		physical.visible_message(span_notice("\The [src] shuts down."))
 	enabled = 0
 	update_appearance()

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -68,13 +68,7 @@
 	kill_program(forced = TRUE)
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(soundloop)
-	for(var/H in all_components)
-		var/obj/item/computer_hardware/CH = all_components[H]
-		if(CH.holder == src)
-			CH.on_remove(src)
-			CH.holder = null
-			all_components.Remove(CH.device_type)
-			qdel(CH)
+	QDEL_LIST(all_components)
 	physical = null
 	return ..()
 
@@ -438,7 +432,7 @@
 		idle_threads.Remove(P)
 	if(looping_sound)
 		soundloop.stop()
-	if(loud)
+	if(loud && !QDELETED(physical))
 		physical.visible_message(span_notice("\The [src] shuts down."))
 	enabled = 0
 	update_appearance()

--- a/code/modules/modular_computers/hardware/CPU.dm
+++ b/code/modules/modular_computers/hardware/CPU.dm
@@ -12,7 +12,7 @@
 	var/max_idle_programs = 2 // 2 idle, + 1 active = 3 as said in description.
 	device_type = MC_CPU
 
-/obj/item/computer_hardware/processor_unit/on_remove(obj/item/modular_computer/MC, mob/user)
+/obj/item/computer_hardware/processor_unit/on_remove(obj/item/modular_computer/MC, mob/user, deleting = FALSE)
 	MC.shutdown_computer()
 
 /obj/item/computer_hardware/processor_unit/small

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -105,9 +105,9 @@
 	return
 
 // Called when component is removed from PC.
-/obj/item/computer_hardware/proc/on_remove(obj/item/modular_computer/M, mob/living/user)
+/obj/item/computer_hardware/proc/on_remove(obj/item/modular_computer/M, mob/living/user, deleting = FALSE)
 	if(M.physical || !QDELETED(M))
-		try_eject(forced = TRUE)
+		try_eject(forced = TRUE, deleting = deleting)
 
 // Called when someone tries to insert something in it - paper in printer, card in card reader, etc.
 /obj/item/computer_hardware/proc/try_insert(obj/item/I, mob/living/user = null)
@@ -122,5 +122,5 @@
  * * user - The mob requesting the eject.
  * * forced - Whether this action should be forced in some way.
  */
-/obj/item/computer_hardware/proc/try_eject(mob/living/user = null, forced = FALSE)
+/obj/item/computer_hardware/proc/try_eject(mob/living/user = null, forced = FALSE, deleting = FALSE)
 	return FALSE

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -40,7 +40,7 @@
 	return TRUE
 
 
-/obj/item/computer_hardware/ai_slot/try_eject(mob/living/user = null, forced = FALSE)
+/obj/item/computer_hardware/ai_slot/try_eject(mob/living/user = null, forced = FALSE, deleting = FALSE)
 	if(!stored_card)
 		to_chat(user, span_warning("There is no card in \the [src]."))
 		return FALSE

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -16,7 +16,7 @@
 		battery = new battery_type(src)
 
 /obj/item/computer_hardware/battery/Destroy()
-	battery = null
+	QDEL_NULL(battery)
 	return ..()
 
 ///What happens when the battery is removed (or deleted) from the module, through try_eject() or not.
@@ -60,6 +60,7 @@
 			to_chat(user, span_notice("You detach \the [battery] from \the [src]."))
 		else
 			battery.forceMove(drop_location())
+		battery = null
 		return TRUE
 
 /obj/item/stock_parts/cell/computer

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -50,18 +50,16 @@
 
 	return TRUE
 
-/obj/item/computer_hardware/battery/try_eject(mob/living/user, forced = FALSE)
+/obj/item/computer_hardware/battery/try_eject(mob/living/user, forced = FALSE, deleting = FALSE)
 	if(!battery)
 		to_chat(user, span_warning("There is no power cell connected to \the [src]."))
 		return FALSE
-	else
-		if(user)
-			user.put_in_hands(battery)
-			to_chat(user, span_notice("You detach \the [battery] from \the [src]."))
-		else
-			battery.forceMove(drop_location())
-		battery = null
-		return TRUE
+	if(deleting)
+		QDEL_NULL(battery)
+		return FALSE
+	battery.forceMove(drop_location())
+	battery = null
+	return TRUE
 
 /obj/item/stock_parts/cell/computer
 	name = "standard battery"

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -86,9 +86,13 @@
 	return TRUE
 
 
-/obj/item/computer_hardware/card_slot/try_eject(mob/living/user = null, forced = FALSE)
+/obj/item/computer_hardware/card_slot/try_eject(mob/living/user = null, forced = FALSE, deleting = FALSE)
 	if(!stored_card)
 		to_chat(user, span_warning("There are no cards in \the [src]."))
+		return FALSE
+
+	if(deleting)
+		QDEL_NULL(stored_card)
 		return FALSE
 
 	if(user && !issilicon(user) && in_range(src, user))

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -10,7 +10,7 @@
 	var/used_capacity = 0
 	var/list/stored_files = list() // List of stored files on this drive. DO NOT MODIFY DIRECTLY!
 
-/obj/item/computer_hardware/hard_drive/on_remove(obj/item/modular_computer/MC, mob/user)
+/obj/item/computer_hardware/hard_drive/on_remove(obj/item/modular_computer/MC, mob/user, deleting = FALSE)
 	MC.shutdown_computer()
 
 /obj/item/computer_hardware/hard_drive/proc/install_default_programs()

--- a/code/modules/modular_computers/hardware/portable_disk.dm
+++ b/code/modules/modular_computers/hardware/portable_disk.dm
@@ -8,7 +8,7 @@
 	max_capacity = 16
 	device_type = MC_SDD
 
-/obj/item/computer_hardware/hard_drive/portable/on_remove(obj/item/modular_computer/MC, mob/user)
+/obj/item/computer_hardware/hard_drive/portable/on_remove(obj/item/modular_computer/MC, mob/user, deleting = FALSE)
 	return //this is a floppy disk, let's not shut the computer down when it gets pulled out.
 
 /obj/item/computer_hardware/hard_drive/portable/install_default_programs()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Make tablet Destroy() actually delete component contents as well. This will cause both batteries and inserted ID's to be deleted if the tablet or modular computer is either deleted via the admin commands, or deleted by explosions or similar.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/33292112/182876796-afb398ef-657a-43f4-a49c-1ee89cc91f01.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Tablet batteries and ID's now properly delete.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
