### PR TITLE
Adjusts buckshot and slug damage.

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,8 @@
 /obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 50
+	damage = 35
 	sharpness = SHARP_POINTY
+	armour_penetration = 30
 	wound_bonus = 0
 
 /obj/projectile/bullet/shotgun_slug/executioner
@@ -77,7 +78,7 @@
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 7.5
+	damage = 10
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts buckshot damage from 7.5 to 10 per pellet, up to a total of 60 damage.
Adjusts slug damage from 50 to 35 and it's armor piercing to 30.

## Why It's Good For The Game

It makes buckshot actually good again while also making slugs less powerful while giving them a seperate use case.

## Changelog
:cl:
balance: Buckshot now does 60 damage if all pellets land.
balance: Shotgun slugs now do 35 damage, but have an armor piercing value of 30.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
