### PR TITLE
remove abundant airlocks from maintbay

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -11382,10 +11382,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Maintenance";
-	req_access_txt = "47"
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "ckw" = (
@@ -11409,10 +11405,6 @@
 	pixel_y = 28
 	},
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Maintenance";
-	req_access_txt = "47"
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/secondary)
 "ckz" = (
@@ -11422,10 +11414,6 @@
 	name = "Hal's Custom";
 	pixel_x = 7;
 	pixel_y = 14
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Maintenance";
-	req_access_txt = "47"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
@@ -21500,13 +21488,13 @@
 "fen" = (
 /obj/structure/table,
 /obj/item/paper/guides/mos6502_reference_sheet{
-	pixel_y = 5;
-	pixel_x = 12
+	pixel_x = 12;
+	pixel_y = 5
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/item/paper/guides/mainframe_reference{
-	pixel_y = 5;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
 /area/science/misc_lab)
@@ -23147,8 +23135,8 @@
 "fIw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt{
-	pixel_y = -1;
-	pixel_x = -13
+	pixel_x = -13;
+	pixel_y = -1
 	},
 /obj/item/cigbutt{
 	pixel_x = 4;
@@ -52599,13 +52587,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/service/bar)
-"qIV" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Maintenance";
-	req_access_txt = "47"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
 "qJm" = (
 /obj/effect/mapping_helpers/simple_pipes/cyan/visible/layer4,
 /obj/effect/spawner/structure/window/reinforced,
@@ -111964,7 +111945,7 @@ lBp
 thq
 ozE
 ckz
-qIV
+nbv
 dwY
 mhf
 nbv


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/53384660/183287413-5bc86534-645a-4431-8be9-0b5f794292ff.png)
removes those awkard airlocks from maintbay
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
too many airlocks
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: removed abundant airlocks from maintbay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
