### PR TITLE
Makes stunbatons respect stun resistance trait

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -266,9 +266,7 @@
 	if(!target.IsKnockdown())
 		to_chat(target, span_warning("Your muscles seize, making you collapse[trait_check ? ", but your body quickly recovers..." : "!"]"))
 
-	if(trait_check)
-		target.Knockdown(stun_time * 0.1)
-	else
+	if(!trait_check)
 		target.Knockdown(stun_time)
 
 /obj/item/melee/baton/emp_act(severity)


### PR DESCRIPTION
## About The Pull Request

With this PR instead of getting a short knockdown while having stun resistance trait you don't get knockdowned at all, because no matter how short the knockdown is, it is a guaranteed disarm and it will really fuck everything up.

## Why It's Good For The Game

Stun resistance becomes usefull

## Changelog
:cl: SuperSlayer
balance: Stun batons don't knockdown you if you have stun resistance
/:cl:
