### PR TITLE
Prevents the recycler from eating its own parts when dismantled

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -209,6 +209,9 @@
 	L.Unconscious(100)
 	L.adjustBruteLoss(crush_damage)
 
+/obj/machinery/recycler/on_deconstruction()
+	safety_mode = TRUE
+
 /obj/machinery/recycler/deathtrap
 	name = "dangerous old crusher"
 	obj_flags = CAN_BE_HIT | EMAGGED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Makes the recycler enter safety mode immediately before being dismantled to prevent it eating its own parts
Credits to GoblinBackwards

## Why It's Good For The Game

broke thing be fixed unga

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Recyclers no longer eat their own parts when dismantled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
