### PR TITLE
Xeno fix

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -575,7 +575,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		natural_bodytemperature_stabilization(environment, delta_time, times_fired)
 
 	if(!on_fire || areatemp > bodytemperature) // If we are not on fire or the area is hotter
-		adjust_bodytemperature((areatemp - bodytemperature), use_insulation=TRUE, use_steps=TRUE, hardsuit_fix=dna.species.bodytemp_normal - bodytemperature) //The suits adapt to all species
+		var/hardsuit_value = dna ? dna.species.bodytemp_normal - bodytemperature : FALSE
+		adjust_bodytemperature((areatemp - bodytemperature), use_insulation=TRUE, use_steps=TRUE, hardsuit_fix=hardsuit_value) //The suits adapt to all species
 
 /**
  * Used to stabilize the body temperature back to normal on living mobs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game

Xenos no longer runtime on life ticks
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Xenos no longer runtime trying to adjust their body temperature according to their dna.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
