### PR TITLE
Removes uplink implant cost when its not your preference

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -400,6 +400,10 @@
 					uplink_loc = P
 			if(UPLINK_PEN)
 				uplink_loc = P
+				if(!uplink_loc)
+					uplink_loc = PDA
+				if(!uplink_loc)
+					uplink_loc = R
 			if(UPLINK_IMPLANT)
 				implant = TRUE
 				uplink_loc = implant

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -402,15 +402,20 @@
 				uplink_loc = P
 			if(UPLINK_IMPLANT)
 				implant = TRUE
+				uplink_loc = implant
 
-	if(!uplink_loc) // We've looked everywhere, let's just implant you
-		implant = TRUE
+	if(!uplink_loc) // We've looked everywhere, let's just implant you at no extra cost
+		implant = "forced"
 
 	if(implant)
-		var/obj/item/implant/uplink/starting/new_implant = new(traitor_mob)
+		var/obj/item/implant/uplink/new_implant
+		if(implant == "forced")
+			new_implant = new /obj/item/implant/uplink/forced(traitor_mob)
+		else
+			new_implant = new /obj/item/implant/uplink/starting(traitor_mob)
 		new_implant.implant(traitor_mob, null, silent = TRUE)
 		if(!silent)
-			to_chat(traitor_mob, span_boldnotice("Your Syndicate Uplink has been cunningly implanted in you, for a small TC fee. Simply trigger the uplink to access it."))
+			to_chat(traitor_mob, span_boldnotice("Your Syndicate Uplink has been cunningly implanted in you. Simply trigger the uplink to access it."))
 		return new_implant
 
 	. = uplink_loc

--- a/code/game/objects/items/implants/implantuplink.dm
+++ b/code/game/objects/items/implants/implantuplink.dm
@@ -12,7 +12,7 @@
 /obj/item/implant/uplink/Initialize(mapload, owner, uplink_flag)
 	. = ..()
 	var/datum/component/uplink/new_uplink = AddComponent(/datum/component/uplink, _owner = owner, _lockable = TRUE, _enabled = FALSE, uplink_flag = uplink_flag, starting_tc = starting_tc)
-	new_uplink.unlock_text = "Your Syndicate Uplink has been cunningly implanted in you, for a small TC fee. Simply trigger the uplink to access it."
+	new_uplink.unlock_text = "Your Syndicate Uplink has been cunningly implanted in you. Simply trigger the uplink to access it."
 	RegisterSignal(src, COMSIG_COMPONENT_REMOVING, .proc/_component_removal)
 
 /**
@@ -44,3 +44,6 @@
 
 /obj/item/implant/uplink/starting
 	starting_tc = TELECRYSTALS_DEFAULT - UPLINK_IMPLANT_TELECRYSTAL_COST
+
+/obj/item/implant/uplink/forced
+	starting_tc = TELECRYSTALS_DEFAULT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If you roll midround and have lost all the other uplink options, getting an uplink implant charges you 4 TC currently.
For some reason if you had the pen preference, it would not fall back on PDA or radio either, added those.
Removed the implant fallback cost if you do not have the implant preference, it shouldn't happen very often with the pen preference fallbacks added.
Removed the "for a small TC fee" texts, the mind one would never trigger and the other is harder to adjust. The cost is obvious when you pick the preference.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Midrounds happen all the time, they are likely already much lower power level comparatively so we shouldnt nerf them further.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skog
balance: Traitor uplink implant fallback no longer costs 4 TC. If you have the uplink preference, nothing has changed and you will still be charged.
fix: Uplink creation will now look for alternatives in PDA and radio if you have the pen preference.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
