### PR TITLE
PORT: Makes diagonal movement euclidean

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -3,6 +3,7 @@
 // (
 
 #define NUM_E 2.71828183
+#define SQRT_2 1.414214
 
 #define PI 3.1416
 #define INFINITY 1e31 //closer then enough

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -122,7 +122,7 @@
 
 	//We are now going to move
 	var/add_delay = mob.cached_multiplicative_slowdown
-	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay * ( (NSCOMPONENT(direct) && EWCOMPONENT(direct)) ? 2 : 1 ) )) // set it now in case of pulled objects
+	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay * ( (NSCOMPONENT(direct) && EWCOMPONENT(direct)) ? SQRT_2 : 1 ) )) // set it now in case of pulled objects
 	if(old_move_delay + (add_delay*MOVEMENT_DELAY_BUFFER_DELTA) + MOVEMENT_DELAY_BUFFER > world.time)
 		move_delay = old_move_delay
 	else
@@ -144,7 +144,7 @@
 	. = ..()
 
 	if((direct & (direct - 1)) && mob.loc == new_loc) //moved diagonally successfully
-		add_delay *= 2
+		add_delay *= SQRT_2
 	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay))
 	move_delay += add_delay
 	if(.) // If mob is null here, we deserve the runtime


### PR DESCRIPTION
## About The Pull Request

Ports tgstation/tgstation#63058 which ports Citadel-Station-13/Citadel-Station-13#14911.

To quote from the other PR:


> To quote from the other PR:
> 
> "Right now, diagonal movement takes twice as long as orthogonal movement. In other words, in terms of mob movement, SS13 treats the tile grid as a taxicab geometry. The issue here is that much of the game doesn't. Projectiles are euclidean: it takes just as much time to move 10 meters diagonally as it does to move 10 meters orthogonally. The thing is, 10 meters diagonally is just under 7 meters north/south and 7 meters east/west, which always takes the equivalent of 14 orthogonal tile movements for units.
> 
> In other words: on diagonals, projectiles move sqrt(2) times as fast as mobs do. This fixes that."


## Why It's Good For The Game

Makes movement feel smoother, and makes running more engaging by allowing you to optimise your route.

## Changelog
:cl:
balance: Diagonal movement is now slightly faster.
/:cl: