### PR TITLE
Stops Durand shield from taking infinite damage.

### DIFF
--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -151,7 +151,7 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 	///To keep track of things during the animation
 	var/switching = FALSE
 	var/currentuser
-
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF //If disabled, the shield will keep burning eternally...
 
 /obj/durand_shield/Initialize(mapload, _chassis, _layer, _dir)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes sure the Durand's shield is resistant against fire, lava and acid; three things that could infinitely damage the shield even if it was turned off. 

## Why It's Good For The Game

Fixes a bug where the durand shield constantly takes damage ad infinitum, while also draining it's battery.
It's more of a bug fix than a balance change since mechs are normally immune to both fire and acid damage.

## Changelog
:cl:
fix: The Durand's shield does not take damage from fire and acid anymore, as it would burn infinitely long.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
