### PR TITLE
Fixes remotes having all access.

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -18,6 +18,7 @@
 
 /obj/item/door_remote/Initialize()
 	. = ..()
+	access_list = SSid_access.accesses_by_region[region_access]
 	RegisterSignal(src, COMSIG_COMPONENT_NTNET_NAK, .proc/bad_signal)
 
 /obj/item/door_remote/proc/bad_signal(datum/source, datum/netdata/data, error_code)


### PR DESCRIPTION
## About The Pull Request
On the tin.
## Why It's Good For The Game
Fixes #180 
## Changelog
:cl:
fix: Door remotes no longer have all access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
