### PR TITLE
Reworks heretic curses

### DIFF
--- a/code/datums/elements/eldritch_curse.dm
+++ b/code/datums/elements/eldritch_curse.dm
@@ -7,12 +7,12 @@
 	var/datum/callback/curse_proc
 	var/datum/callback/uncurse_proc
 
-/datum/element/eldritch_curse/Attach(datum/target, nduration, datum/callback/curse, datum/callback/uncurse)
+/datum/element/eldritch_curse/Attach(datum/target, duration, datum/callback/curse, datum/callback/uncurse)
 	. = ..()
 	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
 
-	src.duration = nduration
+	src.duration = duration
 	src.curse_proc = curse
 	src.uncurse_proc = uncurse
 	RegisterSignal(target, COMSIG_ITEM_PICKUP, .proc/pickup_safety_check)

--- a/code/datums/elements/eldritch_curse.dm
+++ b/code/datums/elements/eldritch_curse.dm
@@ -1,0 +1,41 @@
+/// -- NEW Wiskey's Heretic Curse --
+
+/datum/element/eldritch_curse
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	id_arg_index = 2
+	var/duration = 5 MINUTES
+	var/datum/callback/curse_proc
+	var/datum/callback/uncurse_proc
+
+/datum/element/eldritch_curse/Attach(datum/target, nduration, datum/callback/curse, datum/callback/uncurse)
+	. = ..()
+	if(!isitem(target))
+		return ELEMENT_INCOMPATIBLE
+
+	src.duration = nduration
+	src.curse_proc = curse
+	src.uncurse_proc = uncurse
+	RegisterSignal(target, COMSIG_ITEM_PICKUP, .proc/pickup_safety_check)
+
+/datum/element/eldritch_curse/Detach(datum/target)
+	. = ..()
+	UnregisterSignal(target, list(COMSIG_ITEM_PICKUP))
+
+/datum/element/eldritch_curse/proc/pickup_safety_check(datum/source, mob/user)
+	SIGNAL_HANDLER
+
+	if(curse_safety_check(source, user))
+		return
+
+	curse_proc.Invoke(user)
+	addtimer(CALLBACK(src, curse_proc/uncurse_proc, user),duration)
+	src.Detach(source)
+
+/datum/element/eldritch_curse/proc/curse_safety_check(datum/source, mob/living/carbon/user)
+	if(!istype(user))
+		return FALSE
+
+	if(HAS_TRAIT(user, TRAIT_ANTIMAGIC) || IS_HERETIC_OR_MONSTER(user))
+		return FALSE
+
+	return TRUE

--- a/code/datums/elements/eldritch_curse.dm
+++ b/code/datums/elements/eldritch_curse.dm
@@ -29,7 +29,7 @@
 
 	curse_proc.Invoke(user)
 	addtimer(CALLBACK(src, curse_proc/uncurse_proc, user),duration)
-	src.Detach(source)
+	Detach(source)
 
 /datum/element/eldritch_curse/proc/curse_safety_check(datum/source, mob/living/carbon/user)
 	if(!istype(user))

--- a/code/modules/antagonists/heretic/eldritch_knowledge.dm
+++ b/code/modules/antagonists/heretic/eldritch_knowledge.dm
@@ -383,6 +383,36 @@
 /datum/eldritch_knowledge/curse/proc/uncurse(mob/living/chosen_mob)
 	return
 
+/datum/eldritch_knowledge/curse_item
+	var/timer = 5 MINUTES
+
+/datum/eldritch_knowledge/curse_item/on_finished_recipe(mob/living/user,list/atoms,loc)
+
+	var/list/compiled_list = list()
+
+	for(var/obj/item/requirements as anything in atoms)
+		compiled_list |= requirements.name
+		compiled_list[requirements.name] = requirements
+
+	if(compiled_list.len == 0)
+		to_chat(user, span_warning("There are no valid items."))
+		return FALSE
+
+	var/obj/item/chosen_item = pick(compiled_list)
+	if(!chosen_item)
+		return FALSE
+
+	chosen_item.AddElement(/datum/element/eldritch_curse, timer, CALLBACK(src, .proc/curse), CALLBACK(src, .proc/uncurse))
+	to_chat(user, span_warning("[chosen_item] has been cursed with [name]"))
+
+	return TRUE
+
+/datum/eldritch_knowledge/curse_item/proc/curse(mob/living/chosen_mob)
+	return
+
+/datum/eldritch_knowledge/curse_item/proc/uncurse(mob/living/chosen_mob)
+	return
+
 /*
  * A knowledge subtype lets the heretic summon a monster with the ritual.
  */

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -91,9 +91,9 @@
 		/obj/item/candle = 1
 		)
 	next_knowledge = list(
-		/datum/eldritch_knowledge/curse/corrosion,
+		/datum/eldritch_knowledge/curse_item/corrosion,
 		/datum/eldritch_knowledge/blade_upgrade/ash,
-		/datum/eldritch_knowledge/curse/paralysis
+		/datum/eldritch_knowledge/curse_item/paralysis
 	)
 	route = PATH_ASH
 

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -192,8 +192,8 @@
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/raw_prophet
 	next_knowledge = list(
 		/datum/eldritch_knowledge/blade_upgrade/flesh,
-		/datum/eldritch_knowledge/curse_item/paralysis
-		/datum/eldritch_knowledge/spell/blood_siphon,
+		/datum/eldritch_knowledge/curse_item/paralysis,
+		/datum/eldritch_knowledge/spell/blood_siphon
 	)
 	route = PATH_FLESH
 	

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -192,7 +192,7 @@
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/raw_prophet
 	next_knowledge = list(
 		/datum/eldritch_knowledge/blade_upgrade/flesh,
-		/datum/eldritch_knowledge/curse/paralysis,
+		/datum/eldritch_knowledge/curse_item/paralysis
 		/datum/eldritch_knowledge/spell/blood_siphon,
 	)
 	route = PATH_FLESH

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -123,7 +123,7 @@
 	spell_to_add = /obj/effect/proc_holder/spell/aoe_turf/rust_conversion
 	next_knowledge = list(
 		/datum/eldritch_knowledge/blade_upgrade/rust,
-		/datum/eldritch_knowledge/curse/corrosion,
+		/datum/eldritch_knowledge/curse_item/corrosion,
 		/datum/eldritch_knowledge/crucible
 	)
 	route = PATH_RUST

--- a/code/modules/antagonists/heretic/side_paths/ash_flesh.dm
+++ b/code/modules/antagonists/heretic/side_paths/ash_flesh.dm
@@ -13,10 +13,10 @@
 	result_atoms = list(/obj/item/clothing/neck/eldritch_amulet)
 	route = PATH_SIDE
 
-/datum/eldritch_knowledge/curse/paralysis
+/datum/eldritch_knowledge/curse_item/paralysis
 	name = "Curse of Paralysis"
 	gain_text = "Corrupt their flesh, make them bleed."
-	desc = "Curse someone for 5 minutes of inability to walk. Sacrifice a knife, a pool of blood, a pair of legs, a hatchet and an item that the victim touched with their bare hands. "
+	desc = "Curse an item to inflict the curse of paralysis to whoever it touches it. The curse will make its victim unable to walk for 5 minutes. Sacrifice a pair of legs, a hatchet and the item you want to curse."
 	cost = 1
 	required_atoms = list(
 		/obj/item/bodypart/l_leg = 1,
@@ -27,13 +27,13 @@
 	timer = 5 MINUTES
 	route = PATH_SIDE
 
-/datum/eldritch_knowledge/curse/paralysis/curse(mob/living/chosen_mob)
+/datum/eldritch_knowledge/curse_item/paralysis/curse(mob/living/chosen_mob)
 	. = ..()
 	ADD_TRAIT(chosen_mob,TRAIT_PARALYSIS_L_LEG,MAGIC_TRAIT)
 	ADD_TRAIT(chosen_mob,TRAIT_PARALYSIS_R_LEG,MAGIC_TRAIT)
 
 
-/datum/eldritch_knowledge/curse/paralysis/uncurse(mob/living/chosen_mob)
+/datum/eldritch_knowledge/curse_item/paralysis/uncurse(mob/living/chosen_mob)
 	. = ..()
 	REMOVE_TRAIT(chosen_mob,TRAIT_PARALYSIS_L_LEG,MAGIC_TRAIT)
 	REMOVE_TRAIT(chosen_mob,TRAIT_PARALYSIS_R_LEG,MAGIC_TRAIT)

--- a/code/modules/antagonists/heretic/side_paths/rust_ash.dm
+++ b/code/modules/antagonists/heretic/side_paths/rust_ash.dm
@@ -11,10 +11,10 @@
 	result_atoms = list(/obj/item/reagent_containers/glass/beaker/eldritch)
 	route = PATH_SIDE
 
-/datum/eldritch_knowledge/curse/corrosion
+/datum/eldritch_knowledge/curse_item/corrosion
 	name = "Curse of Corrosion"
 	gain_text = "Cursed land, cursed man, cursed mind."
-	desc = "Curse someone for 2 minutes of vomiting and major organ damage. Using a wirecutter, a pool of vomit, a heart and an item that the victim touched  with their bare hands."
+	desc = "Curse an item to inflict the curse of corrosion to whoever it touches it. The curse will inflict vomiting and major organ damage for 2 minutes. Using a wirecutter, a pool of blood, a heart and the item you want to curse."
 	cost = 1
 	required_atoms = list(
 		/obj/item/wirecutters = 1,
@@ -28,11 +28,11 @@
 	timer = 2 MINUTES
 	route = PATH_SIDE
 
-/datum/eldritch_knowledge/curse/corrosion/curse(mob/living/chosen_mob)
+/datum/eldritch_knowledge/curse_item/corrosion/curse(mob/living/chosen_mob)
 	. = ..()
 	chosen_mob.apply_status_effect(/datum/status_effect/corrosion_curse)
 
-/datum/eldritch_knowledge/curse/corrosion/uncurse(mob/living/chosen_mob)
+/datum/eldritch_knowledge/curse_item/corrosion/uncurse(mob/living/chosen_mob)
 	. = ..()
 	chosen_mob.remove_status_effect(/datum/status_effect/corrosion_curse)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -710,6 +710,7 @@
 #include "code\datums\elements\dryable.dm"
 #include "code\datums\elements\earhealing.dm"
 #include "code\datums\elements\easily_fragmented.dm"
+#include "code\datums\elements\eldritch_curse.dm"
 #include "code\datums\elements\embed.dm"
 #include "code\datums\elements\empprotection.dm"
 #include "code\datums\elements\eyestab.dm"


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/The-Merchants-Guild/Merchant-Station-13/pull/286

Instead of cursing one person that touched an item, heretics now curse an item to apply the effect to the non heretic that touches said item.

## Why It's Good For The Game

Makes heretic curses usefull and not suck 

## Changelog
:cl: eeSPee, ported by SuperSlayer
balance: Heretics curses now curse items instead of a person who touched them, making the items apply the curse effects on pickup
/:cl:
