### PR TITLE
Ports rust heretic rework

### DIFF
--- a/code/__DEFINES/turfs.dm
+++ b/code/__DEFINES/turfs.dm
@@ -6,3 +6,10 @@
 #define CHANGETURF_RECALC_ADJACENT 32 //Immediately recalc adjacent atmos turfs instead of queuing.
 
 #define IS_OPAQUE_TURF(turf) (turf.directional_opacity == ALL_CARDINALS)
+
+// Defines for turf rust resistance
+#define RUST_RESISTANCE_BASIC 1
+#define RUST_RESISTANCE_REINFORCED 2
+#define RUST_RESISTANCE_TITANIUM 3
+#define RUST_RESISTANCE_ORGANIC 4
+#define RUST_RESISTANCE_ABSOLUTE 5

--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -46,6 +46,8 @@ Simple datum which is instanced once per type and is used for every object of sa
 	var/cached_texture_filter_icon
 	///What type of shard the material will shatter to
 	var/obj/item/shard_type
+	///How resistant the material is to rusting when applied to a turf
+	var/mat_rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /** Handles initializing the material.
  *
@@ -149,6 +151,7 @@ Simple datum which is instanced once per type and is used for every object of sa
 			O.heavyfootstep = turf_sound_override
 	if(alpha < 255)
 		T.AddElement(/datum/element/turf_z_transparency, TRUE)
+	T.rust_resistance = mat_rust_resistance
 	return
 
 /datum/material/proc/get_greyscale_config_for(datum/greyscale_config/config_path)

--- a/code/datums/materials/alloys.dm
+++ b/code/datums/materials/alloys.dm
@@ -40,6 +40,7 @@
 	sheet_type = /obj/item/stack/sheet/plasteel
 	categories = list(MAT_CATEGORY_RIGID=TRUE, MAT_CATEGORY_BASE_RECIPES=TRUE, MAT_CATEGORY_ITEM_MATERIAL=TRUE)
 	composition = list(/datum/material/iron=1, /datum/material/plasma=1)
+	mat_rust_resistance = RUST_RESISTANCE_REINFORCED
 
 /datum/material/alloy/plasteel/on_applied_obj(obj/item/target_item, amount, material_flags)
 	. = ..()
@@ -73,6 +74,7 @@
 	sheet_type = /obj/item/stack/sheet/mineral/plastitanium
 	categories = list(MAT_CATEGORY_RIGID=TRUE, MAT_CATEGORY_BASE_RECIPES=TRUE, MAT_CATEGORY_ITEM_MATERIAL=TRUE)
 	composition = list(/datum/material/titanium=1, /datum/material/plasma=1)
+	mat_rust_resistance = RUST_RESISTANCE_TITANIUM
 
 /** Plasmaglass
  *

--- a/code/game/area/areas/ruins/icemoon.dm
+++ b/code/game/area/areas/ruins/icemoon.dm
@@ -17,6 +17,7 @@
 	base_icon_state = "block"
 	smoothing_flags = NONE
 	canSmoothWith = null
+	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /area/ruin/powered/mailroom
 	name = "Abandoned Post Office"

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -20,8 +20,7 @@
 	icon = 'icons/turf/walls.dmi'
 	explosion_block = 50
 
-/turf/closed/indestructible/rust_heretic_act()
-	return
+	rust_resistance = RUST_RESISTANCE_ABSOLUTE
 
 /turf/closed/indestructible/TerraformTurf(path, new_baseturf, flags, defer_change = FALSE, ignore_air = FALSE)
 	return

--- a/code/game/turfs/closed/wall/material_walls.dm
+++ b/code/game/turfs/closed/wall/material_walls.dm
@@ -9,6 +9,7 @@
 	canSmoothWith = list(SMOOTH_GROUP_MATERIAL_WALLS)
 	rcd_memory = null
 	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
+	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/closed/wall/material/break_wall()
 	for(var/i in custom_materials)

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -7,6 +7,7 @@
 	rcd_memory = null
 	var/last_event = 0
 	var/active = null
+	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/closed/wall/mineral/gold
 	name = "gold wall"
@@ -251,8 +252,7 @@
 	canSmoothWith = list(SMOOTH_GROUP_TITANIUM_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS)
 	custom_materials = list(/datum/material/titanium = 4000)
 
-/turf/closed/wall/mineral/titanium/rust_heretic_act()
-	return // titanium does not rust
+	rust_resistance = RUST_RESISTANCE_TITANIUM
 
 /turf/closed/wall/mineral/titanium/nodiagonal
 	icon = 'icons/turf/walls/shuttle_wall.dmi'
@@ -327,8 +327,7 @@
 	canSmoothWith = list(SMOOTH_GROUP_PLASTITANIUM_WALLS, SMOOTH_GROUP_SYNDICATE_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS)
 	custom_materials = list(/datum/material/alloy/plastitanium = 4000)
 
-/turf/closed/wall/mineral/plastitanium/rust_heretic_act()
-	return // plastitanium does not rust
+	rust_resistance = RUST_RESISTANCE_TITANIUM
 
 /turf/closed/wall/mineral/plastitanium/nodiagonal
 	icon = 'icons/turf/walls/plastitanium_wall.dmi'

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -230,8 +230,6 @@
 		return ..()
 
 /turf/closed/wall/r_wall/rust_turf()
-	if(turf_flags & NO_RUST)
-		return
 	if(HAS_TRAIT(src, TRAIT_RUSTY))
 		ChangeTurf(/turf/closed/wall/rust)
 		return

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -17,6 +17,8 @@
 	///Dismantled state, related to deconstruction.
 	var/d_state = INTACT
 
+	rust_resistance = RUST_RESISTANCE_REINFORCED
+
 
 /turf/closed/wall/r_wall/deconstruction_hints(mob/user)
 	switch(d_state)
@@ -227,11 +229,11 @@
 	if(the_rcd.canRturf)
 		return ..()
 
-/turf/closed/wall/r_wall/rust_heretic_act()
-	if(prob(50))
+/turf/closed/wall/r_wall/rust_turf()
+	if(turf_flags & NO_RUST)
 		return
 	if(HAS_TRAIT(src, TRAIT_RUSTY))
-		ScrapeAway()
+		ChangeTurf(/turf/closed/wall/rust)
 		return
 	return ..()
 
@@ -246,6 +248,7 @@
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SYNDICATE_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_SYNDICATE_WALLS, SMOOTH_GROUP_PLASTITANIUM_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS)
+	rust_resistance = RUST_RESISTANCE_TITANIUM
 
 /turf/closed/wall/r_wall/syndicate/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	return FALSE

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -7,6 +7,7 @@
 	icon_state = "wall-0"
 	base_icon_state = "wall"
 	explosion_block = 1
+	rust_resistance = RUST_RESISTANCE_BASIC
 
 	thermal_conductivity = WALL_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 62500 //a little over 5 cm thick , 62500 for 1 m by 2.5 m by 0.25 m iron wall. also indicates the temperature at wich the wall will melt (currently only able to melt with H/E pipes)
@@ -308,12 +309,12 @@
 
 	add_overlay(dent_decals)
 
-/turf/closed/wall/rust_heretic_act()
+/turf/closed/wall/rust_turf()
+	if(turf_flags & NO_RUST)
+		return
 	if(HAS_TRAIT(src, TRAIT_RUSTY))
 		ScrapeAway()
 		return
-	if(prob(70))
-		new /obj/effect/temp_visual/glowing_rune(src)
 	return ..()
 
 #undef MAX_DENT_DECALS

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -310,8 +310,6 @@
 	add_overlay(dent_decals)
 
 /turf/closed/wall/rust_turf()
-	if(turf_flags & NO_RUST)
-		return
 	if(HAS_TRAIT(src, TRAIT_RUSTY))
 		ScrapeAway()
 		return

--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -11,6 +11,7 @@
 	canSmoothWith = list(SMOOTH_GROUP_TURF_CHASM)
 	density = TRUE //This will prevent hostile mobs from pathing into chasms, while the canpass override will still let it function like an open turf
 	bullet_bounce_sound = null //abandon all hope ye who enter
+	rust_resistance = RUST_RESISTANCE_ABSOLUTE
 
 /turf/open/chasm/Initialize()
 	. = ..()

--- a/code/game/turfs/open/floor/catwalk_plating.dm
+++ b/code/game/turfs/open/floor/catwalk_plating.dm
@@ -17,6 +17,8 @@
 	heavyfootstep = FOOTSTEP_CATWALK
 	var/covered = TRUE
 
+	rust_resistance = RUST_RESISTANCE_BASIC
+
 /turf/open/floor/plating/catwalk_floor/Initialize()
 	. = ..()
 	update_icon(UPDATE_OVERLAYS)

--- a/code/game/turfs/open/floor/iron_floor.dm
+++ b/code/game/turfs/open/floor/iron_floor.dm
@@ -1,6 +1,7 @@
 /turf/open/floor/iron
 	icon_state = "floor"
 	floor_tile = /obj/item/stack/tile/iron/base
+	rust_resistance = RUST_RESISTANCE_BASIC
 
 /turf/open/floor/iron/setup_broken_states()
 	return list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
@@ -12,13 +13,6 @@
 /turf/open/floor/iron/examine(mob/user)
 	. = ..()
 	. += span_notice("There's a <b>small crack</b> on the edge of it.")
-
-
-/turf/open/floor/iron/rust_heretic_act()
-	if(prob(70))
-		new /obj/effect/temp_visual/glowing_rune(src)
-	ChangeTurf(/turf/open/floor/plating/rust)
-
 
 /turf/open/floor/iron/update_icon_state()
 	if(broken || burnt)

--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -88,12 +88,10 @@
 	icon_state = "titanium"
 	floor_tile = /obj/item/stack/tile/mineral/titanium
 	custom_materials = list(/datum/material/titanium = 500)
+	rust_resistance = RUST_RESISTANCE_TITANIUM
 
 /turf/open/floor/mineral/titanium/setup_broken_states()
 	return list("titanium_dam1","titanium_dam2","titanium_dam3","titanium_dam4","titanium_dam5")
-
-/turf/open/floor/mineral/titanium/rust_heretic_act()
-	return // titanium does not rust
 
 /turf/open/floor/mineral/titanium/airless
 	initial_gas_mix = AIRLESS_ATMOS
@@ -172,12 +170,10 @@
 	icon_state = "plastitanium"
 	floor_tile = /obj/item/stack/tile/mineral/plastitanium
 	custom_materials = list(/datum/material/alloy/plastitanium = 500)
+	rust_resistance = RUST_RESISTANCE_TITANIUM
 
 /turf/open/floor/mineral/plastitanium/setup_broken_states()
 	return list("plastitanium_dam1","plastitanium_dam2","plastitanium_dam3","plastitanium_dam4","plastitanium_dam5")
-
-/turf/open/floor/mineral/plastitanium/rust_heretic_act()
-	return // plastitanium does not rust
 
 /turf/open/floor/mineral/plastitanium/airless
 	initial_gas_mix = AIRLESS_ATMOS

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -17,6 +17,7 @@
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+	rust_resistance = RUST_RESISTANCE_BASIC
 
 	var/attachment_holes = TRUE
 
@@ -91,11 +92,6 @@
 		broken = FALSE
 
 	return TRUE
-
-/turf/open/floor/plating/rust_heretic_act()
-	if(prob(70))
-		new /obj/effect/temp_visual/glowing_rune(src)
-	return ..()
 
 /turf/open/floor/plating/make_plating(force = FALSE)
 	return

--- a/code/game/turfs/open/floor/plating/asteroid.dm
+++ b/code/game/turfs/open/floor/plating/asteroid.dm
@@ -12,6 +12,9 @@
 	barefootstep = FOOTSTEP_SAND
 	clawfootstep = FOOTSTEP_SAND
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+
+	rust_resistance = RUST_RESISTANCE_ORGANIC
+
 	/// Base turf type to be created by the tunnel
 	var/turf_type = /turf/open/floor/plating/asteroid
 	/// Probability floor has a different icon state

--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -15,6 +15,7 @@
 	icon_state = "alienpod1"
 	base_icon_state = "alienpod1"
 	tiled_dirt = FALSE
+	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/open/floor/plating/abductor/setup_broken_states()
 	return list("alienpod1")
@@ -29,6 +30,7 @@
 	icon_state = "alienplating"
 	base_icon_state = "alienplating"
 	tiled_dirt = FALSE
+	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/open/floor/plating/abductor2/break_tile()
 	return //unbreakable
@@ -57,6 +59,8 @@
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	tiled_dirt = FALSE
 	var/smooth_icon = 'icons/turf/floors/ash.dmi'
+
+	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 
 /turf/open/floor/plating/ashplanet/Initialize()
@@ -125,6 +129,7 @@
 	barefootstep = FOOTSTEP_SAND
 	clawfootstep = FOOTSTEP_SAND
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/open/floor/plating/beach/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	return
@@ -229,6 +234,7 @@
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/open/floor/plating/ice/Initialize()
 	. = ..()
@@ -309,6 +315,7 @@
 	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_FLOOR_GRASS)
 	layer = HIGH_TURF_LAYER
 	var/smooth_icon = 'icons/turf/floors/grass.dmi'
+	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/open/floor/plating/grass/setup_broken_states()
 	return list("damaged")
@@ -336,6 +343,7 @@
 	clawfootstep = FOOTSTEP_SAND
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	tiled_dirt = FALSE
+	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/open/floor/plating/sandy_dirt/setup_broken_states()
 	return list("sand_damaged")

--- a/code/game/turfs/open/floor/plating/planet.dm
+++ b/code/game/turfs/open/floor/plating/planet.dm
@@ -14,6 +14,7 @@
 	clawfootstep = FOOTSTEP_SAND
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	tiled_dirt = FALSE
+	rust_resistance = RUST_RESISTANCE_ORGANIC
 
 /turf/open/floor/plating/dirt/setup_broken_states()
 	return list("dirt")

--- a/code/game/turfs/open/floor/reinf_floor.dm
+++ b/code/game/turfs/open/floor/reinf_floor.dm
@@ -12,6 +12,7 @@
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	tiled_dirt = FALSE
+	rust_resistance = RUST_RESISTANCE_REINFORCED
 
 
 /turf/open/floor/engine/examine(mob/user)

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -17,6 +17,8 @@
 	clawfootstep = FOOTSTEP_LAVA
 	heavyfootstep = FOOTSTEP_LAVA
 
+	rust_resistance = RUST_RESISTANCE_ABSOLUTE
+
 /turf/open/lava/ex_act(severity, target)
 	contents_explosion(severity, target)
 

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -20,6 +20,7 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 	baseturfs = /turf/open/openspace
 	intact = FALSE //this means wires go on top
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	rust_resistance = RUST_RESISTANCE_ABSOLUTE
 	var/can_cover_up = TRUE
 	var/can_build_on = TRUE
 

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -4,6 +4,8 @@
 	name = "\proper space"
 	intact = 0
 
+	rust_resistance = RUST_RESISTANCE_ABSOLUTE
+
 	temperature = TCMB
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 700000

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -68,6 +68,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	/// See __DEFINES/construction.dm for RCD_MEMORY_*.
 	var/rcd_memory
 
+	var/rust_resistance = RUST_RESISTANCE_ORGANIC
+
 /turf/vv_edit_var(var_name, new_value)
 	var/static/list/banned_edits = list("x", "y", "z")
 	if(var_name in banned_edits)
@@ -549,6 +551,30 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /turf/proc/acid_melt()
 	return
+
+/// Check if the heretic is strong enough to rust this turf
+/turf/rust_heretic_act(mob/living/source)
+	if(turf_flags & NO_RUST)
+		return
+	// Rust walkers and the spreading from an ascended rust heretic rune use this value
+	var/heretic_rust_strength = 4
+	if(!isnull(source))
+		var/datum/antagonist/heretic/heretic_data = IS_HERETIC(source)
+		if(heretic_data)
+			heretic_rust_strength = heretic_data.rust_strength
+
+	if(heretic_rust_strength >= rust_resistance)
+		rust_turf()
+		if(prob(70))
+			new /obj/effect/temp_visual/glowing_rune(src)
+
+/// Override this to change behaviour when being rusted by a heretic
+/turf/proc/rust_turf()
+	if(turf_flags & NO_RUST)
+		return
+	if(HAS_TRAIT(src, TRAIT_RUSTY))
+		return
+	AddComponent(/datum/component/rust)
 
 /turf/handle_fall(mob/faller)
 	if(has_gravity(src))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -554,8 +554,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /// Check if the heretic is strong enough to rust this turf
 /turf/rust_heretic_act(mob/living/source)
-	if(turf_flags & NO_RUST)
-		return
 	// Rust walkers and the spreading from an ascended rust heretic rune use this value
 	var/heretic_rust_strength = 4
 	if(!isnull(source))
@@ -570,8 +568,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /// Override this to change behaviour when being rusted by a heretic
 /turf/proc/rust_turf()
-	if(turf_flags & NO_RUST)
-		return
 	if(HAS_TRAIT(src, TRAIT_RUSTY))
 		return
 	AddComponent(/datum/component/rust)

--- a/code/modules/antagonists/heretic/eldritch_antag.dm
+++ b/code/modules/antagonists/heretic/eldritch_antag.dm
@@ -24,6 +24,8 @@
 	var/list/researched_knowledge = list()
 	var/total_sacrifices = 0
 	var/ascended = FALSE
+	/// Controls what types of turf we can spread rust to, increases as we unlock more powerful rust abilites
+	var/rust_strength = 0
 
 /datum/antagonist/heretic/ui_static_data(mob/user)
 	var/list/data = list()
@@ -230,6 +232,17 @@
 
 /datum/antagonist/heretic/proc/get_knowledge(wanted)
 	return researched_knowledge[wanted]
+
+/datum/antagonist/heretic/proc/increase_rust_strength(side_path_only = FALSE)
+	if(side_path_only && get_knowledge(/datum/heretic_knowledge/limited_amount/base_rust))
+		return
+
+	rust_strength++
+
+/datum/antagonist/heretic/proc/set_rust_strength(strength)
+	if(ISNAN(strength))
+		return
+	rust_strength = strength
 
 /datum/antagonist/heretic/proc/get_all_knowledge()
 	return researched_knowledge

--- a/code/modules/antagonists/heretic/eldritch_antag.dm
+++ b/code/modules/antagonists/heretic/eldritch_antag.dm
@@ -234,13 +234,13 @@
 	return researched_knowledge[wanted]
 
 /datum/antagonist/heretic/proc/increase_rust_strength(side_path_only = FALSE)
-	if(side_path_only && get_knowledge(/datum/heretic_knowledge/limited_amount/base_rust))
+	if(side_path_only && get_knowledge(/datum/eldritch_knowledge/starting/base_rust))
 		return
 
 	rust_strength++
 
 /datum/antagonist/heretic/proc/set_rust_strength(strength)
-	if(ISNAN(strength))
+	if(isnum(strength))
 		return
 	rust_strength = strength
 

--- a/code/modules/antagonists/heretic/eldritch_knowledge.dm
+++ b/code/modules/antagonists/heretic/eldritch_knowledge.dm
@@ -558,6 +558,9 @@
 		var/mob/living/carbon/human/human_user = user
 		human_user.physiology.brute_mod *= 0.5
 		human_user.physiology.burn_mod *= 0.5
+
+	heretic_datum.increase_rust_strength()
+
 	return TRUE
 
 /datum/eldritch_knowledge/final/cleanup_atoms(list/selected_atoms)

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -12,7 +12,9 @@
 
 /datum/eldritch_knowledge/rust_fist
 	name = "Grasp of Rust"
-	desc = "Empowers your Mansus Grasp to deal 500 damage to non-living matter and rust any surface it touches. Already rusted surfaces are destroyed. You only rust surfaces and machinery while in combat mode."
+	desc = "Your Mansus Grasp will deal 500 damage to non-living matter and rust any surface it touches. \
+		Already rusted surfaces are destroyed. Surfaces and structures can only be rusted by using Right-Click. \
+		Allows you to rust basic iron walls and floors."
 	gain_text = "On the ceiling of the Mansus, rust grows as moss does on a stone."
 	cost = 1
 	next_knowledge = list(/datum/eldritch_knowledge/rust_regen)
@@ -28,6 +30,8 @@
 /datum/eldritch_knowledge/rust_fist/on_gain(mob/user)
 	RegisterSignal(user, COMSIG_HERETIC_MANSUS_GRASP_ATTACK, .proc/on_mansus_grasp)
 	RegisterSignal(user, COMSIG_HERETIC_BLADE_ATTACK, .proc/on_eldritch_blade)
+	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
+	our_heretic.increase_rust_strength()
 
 /datum/eldritch_knowledge/rust_fist/on_lose(mob/user)
 	UnregisterSignal(user, list(COMSIG_HERETIC_MANSUS_GRASP_ATTACK, COMSIG_HERETIC_BLADE_ATTACK))
@@ -38,7 +42,7 @@
 	if(!issilicon(target) && !(target.mob_biotypes & MOB_ROBOTIC))
 		return
 
-	target.rust_heretic_act()
+	target.rust_heretic_act(source)
 
 /datum/eldritch_knowledge/rust_fist/proc/on_eldritch_blade(mob/living/user, mob/living/target)
 	SIGNAL_HANDLER
@@ -105,11 +109,18 @@
 
 /datum/eldritch_knowledge/mark/rust_mark
 	name = "Mark of Rust"
-	desc = "Your Mansus Grasp now applies the Mark of Rust on hit. Attack the afflicted with your Sickly Blade to detonate the mark. Upon detonation, the Mark of Rust has a chance to deal between 0 to 200 damage to 75% of your enemy's held items."
+	desc = "Your Mansus Grasp now applies the Mark of Rust. The mark is triggered from an attack with your Rusty Blade. \
+		When triggered, the victim's organs and equipment will have a 75% chance to sustain damage and may be destroyed. \
+		Allows you to rust reinforced walls and floors as well as plasteel."
 	gain_text = "Rusted Hills help those in dire need at a cost."
 	next_knowledge = list(/datum/eldritch_knowledge/knowledge_ritual/rust)
 	route = PATH_RUST
 	mark_type = /datum/status_effect/eldritch/rust
+
+/datum/eldritch_knowledge/mark/rust_mark/on_gain(mob/user)
+	. = ..()
+	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
+	our_heretic.increase_rust_strength()
 
 /datum/eldritch_knowledge/knowledge_ritual/rust
 	next_knowledge = list(/datum/eldritch_knowledge/spell/area_conversion)
@@ -117,7 +128,9 @@
 
 /datum/eldritch_knowledge/spell/area_conversion
 	name = "Agressive Spread"
-	desc = "Spreads rust to nearby surfaces. Already rusted surfaces are destroyed."
+	desc = "Grants you Aggressive Spread, a spell that spreads rust to nearby surfaces. \
+			Already rusted surfaces are destroyed. \
+			Also improves the rusting abilities of non-rust heretics."
 	gain_text = "All wise men know well not to touch the Bound King."
 	cost = 1
 	spell_to_add = /obj/effect/proc_holder/spell/aoe_turf/rust_conversion
@@ -128,10 +141,16 @@
 	)
 	route = PATH_RUST
 
+/datum/eldritch_knowledge/spell/area_conversion/on_gain(mob/user)
+	. = ..()
+	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
+	our_heretic.increase_rust_strength(TRUE)
+
 /datum/eldritch_knowledge/blade_upgrade/rust
 	name = "Toxic Blade"
 	gain_text = "The Blade will guide you through the flesh, should you let it."
-	desc = "Your blade of choice will now poison your enemies on hit."
+	desc = "Your Blade now poisons enemies on attack. \
+			Allows you to rust titanium and plastitanium."
 	next_knowledge = list(/datum/eldritch_knowledge/spell/entropic_plume)
 	route = PATH_RUST
 
@@ -139,9 +158,14 @@
 	// No user == target check here, cause it's technically good for the heretic?
 	target.reagents?.add_reagent(/datum/reagent/eldritch, 5)
 
+/datum/eldritch_knowledge/blade_upgrade/rust/on_gain(mob/user)
+	. = ..()
+	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
+	our_heretic.increase_rust_strength(TRUE)
+
 /datum/eldritch_knowledge/spell/entropic_plume
 	name = "Entropic Plume"
-	desc = "You can now send a disorienting plume of pure entropy that blinds, poisons and makes enemies strike each other. It also rusts any tiles it affects."
+	desc = "You can now send a disorienting plume of pure entropy that blinds, poisons and makes enemies strike each other. It also rusts any tiles it affects. Also improves the rusting abilities of non-rust heretics."
 	gain_text = "Messengers of Hope, fear the Rustbringer!"
 	cost = 1
 	spell_to_add = /obj/effect/proc_holder/spell/cone/staggered/entropic_plume
@@ -152,13 +176,19 @@
 		)
 	route = PATH_RUST
 
+/datum/eldritch_knowledge/spell/entropic_plume/on_gain(mob/user)
+	. = ..()
+	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
+	our_heretic.increase_rust_strength(TRUE)
+
 /datum/eldritch_knowledge/final/rust_final
 	name = "Rustbringer's Oath"
 	desc = "The ascension ritual of the Path of Rust. \
 		Bring 3 corpses to a transumation rune on the bridge of the station to complete the ritual. \
 		When completed, the ritual site will endlessly spread rust onto any surface, stopping for nothing. \
 		Additionally, you will become extremely resilient on rust, healing at triple the rate \
-		and becoming immune to many effects and dangers."
+		and becoming immune to many effects and dangers. \
+		You will become able to spread rust to almost anything upon ascending."
 	gain_text = "Champion of rust. Corruptor of steel. Fear the dark, for the RUSTBRINGER has come! \
 		The Blacksmith forges ahead! Rusted Hills, CALL MY NAME! WITNESS MY ASCENSION!"
 	route = PATH_RUST

--- a/code/modules/antagonists/heretic/magic/rust_magic/aggressive_spread.dm
+++ b/code/modules/antagonists/heretic/magic/rust_magic/aggressive_spread.dm
@@ -18,7 +18,7 @@
 		var/chance = 100 - (max(get_dist(T,user),1)-1)*100/(range+1)
 		if(!prob(chance))
 			continue
-		T.rust_heretic_act()
+		T.rust_heretic_act(user)
 
 /obj/effect/proc_holder/spell/aoe_turf/rust_conversion/small
 	name = "Rust Conversion"

--- a/code/modules/antagonists/heretic/magic/rust_magic/rust_wave.dm
+++ b/code/modules/antagonists/heretic/magic/rust_magic/rust_wave.dm
@@ -39,7 +39,7 @@
 		if(!X || prob(25))
 			continue
 		var/turf/T = X
-		T.rust_heretic_act()
+		T.rust_heretic_act(usr)
 
 /obj/effect/proc_holder/spell/targeted/projectile/dumbfire/rust_wave/short
 	name = "Small Patron's Reach"


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/65361 read it for information about what does it do

## Why It's Good For The Game

Less RNG shit and more progression

## Changelog
:cl: GoblinBackwards, ported by SuperSlayer
expansion: Heretic now has its ability to rust turfs scale with knowledge.
balance: Heretics now start off with limited rusting abilities, but grow to be able to rust almost anything as they progress
balance: Reinforced walls/floors can be rusted after unlocking Mark of Rust
balance: Titanium and plastitanium can be rusted after unlocking Toxic Blade
balance: Rust heretics can spread rust to almost anything after ascending.
balance: When playing as a non-rust heretic your rusting ability improves when you learn aggressive spread, entropic plume, and when you ascend. You need at least two to rust reinforced walls, and all three to be able to rust titanium.
balance: Rusting reinforced walls is no longer RNG, and instead turns them into a regular rusted wall after being rusted twice.
/:cl:

