### PR TITLE
Readds upgrades to ORM, anchors it

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1234,7 +1234,7 @@
 		/obj/item/stock_parts/micro_laser = 1,
 		/obj/item/stock_parts/manipulator = 1,
 		/obj/item/assembly/igniter = 1)
-	needs_anchored = FALSE
+	needs_anchored = TRUE
 
 /obj/item/circuitboard/machine/ore_silo
 	name = "Ore Silo (Machine Board)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ORM now takes part upgrades into account again. 
Matter bin and Micro laser upgrades sheet generation. Starts at 0.75 sheets per ore (down from 1) at tier 1, tier 2 is old normal. Maxes out at 1.5 sheets per ore.
Micro-manipulator increases point gain. To avoid punishing miners for quickly bringing minerals home, will be 100% on tier 1 and 2 parts. Tier 3 and 4 will be upgrades, maxing out at 150%.

To avoid quite as easily moving it to lavaland, the ORM is now unable to be unwrenched. If you need to move it, you will have to deconstruct it, which includes re-linking it to the ore silo.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Believe it or not, non miners use the ORM.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skog
balance: ORM can no longer be wrenched and moved.
balance: The ORM can now have its parts upgraded again! Tier 2 parts give the same amount of materials as old Tier 1, point generation goes no lower than 100%. Maxes out at 150% ore and point generation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
