### PR TITLE
Buffing Nuke Op Combat Medic Kit.

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -269,10 +269,10 @@
 	new /obj/item/stack/medical/gauze(src)
 	new /obj/item/defibrillator/compact/combat/loaded(src)
 	new /obj/item/reagent_containers/hypospray/combat(src)
-	new /obj/item/reagent_containers/pill/patch/libital(src)
-	new /obj/item/reagent_containers/pill/patch/libital(src)
-	new /obj/item/reagent_containers/pill/patch/aiuri(src)
-	new /obj/item/reagent_containers/pill/patch/aiuri(src)
+	new /obj/item/reagent_containers/hypospray/medipen/salacid(src)
+	new /obj/item/reagent_containers/hypospray/medipen/salacid(src)
+	new /obj/item/reagent_containers/hypospray/medipen/oxandrolone(src)
+	new /obj/item/reagent_containers/hypospray/medipen/oxandrolone(src)
 	new /obj/item/clothing/glasses/hud/health/night(src)
 
 //medibot assembly

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -69,9 +69,9 @@
 	amount_per_transfer_from_this = 10
 	inhand_icon_state = "combat_hypo"
 	icon_state = "combat_hypo"
-	volume = 90
+	volume = 100
 	ignore_flags = 1 // So they can heal their comrades.
-	list_reagents = list(/datum/reagent/medicine/epinephrine = 30, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/atropine = 15)
+	list_reagents = list(/datum/reagent/medicine/epinephrine = 15, /datum/reagent/medicine/morphine = 15, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 10, /datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/coagulant = 20)
 
 /obj/item/reagent_containers/hypospray/combat/nanites
 	name = "experimental combat stimulant injector"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -71,7 +71,7 @@
 	icon_state = "combat_hypo"
 	volume = 100
 	ignore_flags = 1 // So they can heal their comrades.
-	list_reagents = list(/datum/reagent/medicine/epinephrine = 15, /datum/reagent/medicine/morphine = 15, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 10, /datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/coagulant = 20)
+	list_reagents = list(/datum/reagent/medicine/salbutamol = 15, /datum/reagent/medicine/morphine = 15, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 10, /datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/coagulant = 20)
 
 /obj/item/reagent_containers/hypospray/combat/nanites
 	name = "experimental combat stimulant injector"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The kit now comes with 4 of the T3 medipens, 2 for brute, 2 for burn.
The hypospray has been adjusted, it now has a 100u capacity and it no longer has epi. Instead, I've reduced the amounts of atropine and leporazine by 5u each, added 20u sanguirite and replaced epi with salbutamol. This means that the injector can now help treat bleed wounds and fractures.
## Why It's Good For The Game

~I'm dead~ Nukies suffer in terms of healing, ~I died,~ they only get a few patches on the shuttle and because they've been cobbychemd they only contain 2u of decent meds each. Also getting a bleed wound was a massive trouble for nukies and giving them a coagulant makes it much more tolerable. 

## Changelog
:cl:
balance: Combat medic kit has good meds now, and its hypospray also contains coagulant and morphine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
