### PR TITLE
Makes sus grasp stun cyborgs

### DIFF
--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -94,6 +94,8 @@
 		var/mob/living/carbon/carbon_hit = hit
 		carbon_hit.AdjustKnockdown(5 SECONDS)
 		carbon_hit.adjustStaminaLoss(80)
+	else if(iscyborg(hit))
+		hit.Stun(5 SECONDS)
 
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Makes mansus grasp stun cyborgs for 5 seconds

Will be a good acompaniment for https://github.com/AetherStation/AetherStation13/pull/218

## Why It's Good For The Game

I don't simply see any reason why it shouldn't stun cyborgs. Cult stuns, for example, stun cyborgs, so heretic stuns also should.

## Changelog
:cl: SuperSlayer
balance: Mansus grasp now stun cyborgs for 5 seconds.
/:cl: