### PR TITLE
Changes how borg batoning discharging works

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -110,7 +110,7 @@
 		//if a stun is applied or not
 		. = cell.use(chrgdeductamt)
 		cell_charge = cell.charge
-	if(turned_on && cell_check < cell_hit_cost)
+	if(turned_on && cell_charge < cell_hit_cost)
 		//we're below minimum, turn off
 		turned_on = FALSE
 		update_appearance()

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -179,7 +179,7 @@
 		if(!cell)
 			to_chat(user, span_warning("[src] does not have a power source!"))
 		else
-			to_chat(user, span_warning("[borg_check ? "your cell" : [src]] is out of charge."))
+			to_chat(user, span_warning("[borg_check ? "your cell" : src] is out of charge."))
 	update_appearance()
 	add_fingerprint(user)
 

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -100,15 +100,21 @@
 	preload_cell_type = /obj/item/stock_parts/cell/high
 
 /obj/item/melee/baton/proc/deductcharge(chrgdeductamt)
-	if(cell)
+	var/mob/living/silicon/robot/borg_owner = loc
+	var/cell_charge
+	if(borg_owner && istype(borg_owner))
+		. = borg_owner.cell.use(chrgdeductamt + (borg_owner.cell.maxcharge*0.02))
+		cell_charge = borg_owner.cell.charge
+	else if(cell)
 		//Note this value returned is significant, as it will determine
 		//if a stun is applied or not
 		. = cell.use(chrgdeductamt)
-		if(turned_on && cell.charge < cell_hit_cost)
-			//we're below minimum, turn off
-			turned_on = FALSE
-			update_appearance()
-			playsound(src, activate_sound, 75, TRUE, -1)
+		cell_charge = cell.charge
+	if(turned_on && cell_check < cell_hit_cost)
+		//we're below minimum, turn off
+		turned_on = FALSE
+		update_appearance()
+		playsound(src, activate_sound, 75, TRUE, -1)
 
 
 /obj/item/melee/baton/update_icon_state()
@@ -283,6 +289,10 @@
 			playsound(H, 'sound/weapons/genhit.ogg', 50, TRUE)
 			return TRUE
 	return FALSE
+
+///Borg stunbaton. Hit cost is slightly lower because of deducting charge based on the max cell charge.
+/obj/item/melee/baton/loaded/robot
+	cell_hit_cost = 750
 
 //Makeshift stun baton. Replacement for stun gloves.
 /obj/item/melee/baton/cattleprod

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -102,9 +102,9 @@
 /obj/item/melee/baton/proc/deductcharge(chrgdeductamt)
 	var/mob/living/silicon/robot/borg_owner = loc
 	var/cell_charge
-	if(borg_owner && istype(borg_owner))
-		. = borg_owner.cell.use(chrgdeductamt + (borg_owner.cell.maxcharge*0.02))
-		cell_charge = borg_owner.cell.charge
+	if(borg_owner && istype(borg_owner) && chrgdeductamt > 0)
+		. = borg_owner.cell.use(chrgdeductamt + borg_owner.cell.maxcharge*0.02)
+		cell_charge = borg_owner.cell.charge - borg_owner.cell.maxcharge*0.02 //Instead of adding the max cell charge penalty to cell_hit_cost we substract it from cell_charge
 	else if(cell)
 		//Note this value returned is significant, as it will determine
 		//if a stun is applied or not
@@ -167,7 +167,10 @@
 	toggle_on(user)
 
 /obj/item/melee/baton/proc/toggle_on(mob/user)
-	if(cell && cell.charge >= cell_hit_cost)
+	var/mob/living/silicon/robot/borg_owner
+	var/borg_check = borg_owner && istype(borg_owner)
+	var/obj/item/stock_parts/cell/used_cell = borg_check ? borg_owner.cell : cell
+	if(used_cell && used_cell.charge >= cell_hit_cost)
 		turned_on = !turned_on
 		to_chat(user, span_notice("[src] is now [turned_on ? "on" : "off"]."))
 		playsound(src, activate_sound, 75, TRUE, -1)
@@ -176,7 +179,7 @@
 		if(!cell)
 			to_chat(user, span_warning("[src] does not have a power source!"))
 		else
-			to_chat(user, span_warning("[src] is out of charge."))
+			to_chat(user, span_warning("[borg_check ? "your cell" : [src]] is out of charge."))
 	update_appearance()
 	add_fingerprint(user)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -422,7 +422,7 @@
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/restraints/handcuffs/cable/zipties,
-		/obj/item/melee/baton/loaded,
+		/obj/item/melee/baton/loaded/robot,
 		/obj/item/gun/energy/disabler/cyborg,
 		/obj/item/clothing/mask/gas/sechailer/cyborg,
 		/obj/item/extinguisher/mini)


### PR DESCRIPTION
## About The Pull Request

Makes that deducting charge from batons that are used by borgs is made from the borg cell rather then from the batong cell, and also deducting 2% from the borg cell max charge(normal hit cost still is required) to make the baton not effectively infinitive. Gives it to secborgs.

## Why It's Good For The Game

Now how many assistants a borg can stun is upgraded by borg cell upgrading while also making it not very OP.

## Changelog
:cl:
add: Batons used by borgs use borg powercell rather then their own
balance: When borgs use batons they also spend 2% of their maximum cell charge along with normall energy cost
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
