### PR TITLE
Ports Dynamic 2022 from tgstation

### DIFF
--- a/code/__DEFINES/dynamic.dm
+++ b/code/__DEFINES/dynamic.dm
@@ -7,11 +7,15 @@
 /// This ruleset can only be picked once. Anything that does not have a scaling_cost MUST have this.
 #define LONE_RULESET (1 << 2)
 
+/// This is a "heavy" midround ruleset, and should be run later into the round
+#define MIDROUND_RULESET_STYLE_HEAVY "Heavy"
+
+/// This is a "light" midround ruleset, and should be run early into the round
+#define MIDROUND_RULESET_STYLE_LIGHT "Light"
+
 /// No round event was hijacked this cycle
 #define HIJACKED_NOTHING "HIJACKED_NOTHING"
 
 /// This cycle, a round event was hijacked when the last midround event was too recent.
 #define HIJACKED_TOO_RECENT "HIJACKED_TOO_RECENT"
 
-/// This cycle, a round event was hijacked when the next midround event is too soon.
-#define HIJACKED_TOO_SOON "HIJACKED_TOO_SOON"

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -75,26 +75,29 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	/// The maximum time the recurring latejoin ruleset timer is allowed to be.
 	var/latejoin_delay_max = (25 MINUTES)
 
-	/// When world.time is over this number the mode tries to inject a midround ruleset.
-	var/midround_injection_cooldown = 0
+	/// The low bound for the midround roll time splits.
+	/// This number influences where to place midround rolls, making this smaller
+	/// will make midround rolls more frequent, and vice versa.
+	/// A midround will never be able to roll before this.
+	var/midround_lower_bound = 10 MINUTES
 
-	/// The minimum time the recurring midround ruleset timer is allowed to be.
-	var/midround_delay_min = (15 MINUTES)
+	/// The upper bound for the midround roll time splits.
+	/// This number influences where to place midround rolls, making this larger
+	/// will make midround rolls less frequent, and vice versa.
+	/// A midround will never be able to roll farther than this.
+	var/midround_upper_bound = 100 MINUTES
 
-	/// The maximum time the recurring midround ruleset timer is allowed to be.
-	var/midround_delay_max = (35 MINUTES)
+	/// The distance between the chosen midround roll point (which is deterministic),
+	/// and when it can actually roll.
+	/// Basically, if this is set to 5 minutes, and a midround roll point is decided to be at 20 minutes,
+	/// then it can roll anywhere between 15 and 25 minutes.
+	var/midround_roll_distance = 3 MINUTES
 
-	/// If above this threat, increase the chance of injection
-	var/higher_injection_chance_minimum_threat = 70
-
-	/// The chance of injection increase when above higher_injection_chance_minimum_threat
-	var/higher_injection_chance = 15
-
-	/// If below this threat, decrease the chance of injection
-	var/lower_injection_chance_minimum_threat = 10
-
-	/// The chance of injection decrease when above lower_injection_chance_minimum_threat
-	var/lower_injection_chance = 15
+	/// The amount of threat per midround roll.
+	/// Basically, if this is set to 5, then for every 5 threat, one midround roll will be added.
+	/// The equation this is used in rounds up, meaning that if this is set to 5, and you have 6
+	/// threat, then you will get 2 midround rolls.
+	var/threat_per_midround_roll = 6.5
 
 	/// A number between -5 and +5.
 	/// A negative value will give a more peaceful round and
@@ -124,14 +127,48 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	/// The maximum amount of time for antag random events to be hijacked.
 	var/random_event_hijack_maximum = 18 MINUTES
 
+	/// What is the lower bound of when the roundstart annoucement is sent out?
+	var/waittime_l = 600
+
+	/// What is the higher bound of when the roundstart annoucement is sent out?
+	var/waittime_h = 1800
+
+	/// Maximum amount of threat allowed to generate.
+	var/max_threat_level = 100
+
+	/// The extra chance multiplier that a heavy impact midround ruleset will run next time.
+	/// For example, if this is set to 50, then the next heavy roll will be about 50% more likely to happen.
+	var/hijacked_random_event_injection_chance_modifier = 50
+
+	/// Any midround before this point is guaranteed to be light
+	var/midround_light_upper_bound = 25 MINUTES
+
+	/// Any midround after this point is guaranteed to be heavy
+	var/midround_heavy_lower_bound = 55 MINUTES
+
+	/// If there are less than this many players readied, threat level will be lowered.
+	/// This number should be kept fairly low, as there are other measures that population
+	/// impacts Dynamic, such as the requirements variable on rulesets.
+	var/low_pop_player_threshold = 20
+
+	/// The maximum threat that can roll with *zero* players.
+	/// As the number of players approaches `low_pop_player_threshold`, the maximum
+	/// threat level will increase.
+	/// For example, if `low_pop_minimum_threat` is 50, `low_pop_player_threshold` is 20,
+	/// and the number of readied players is 10, then the highest threat that can roll is
+	/// lerp(50, 100, 10 / 20), AKA 75.
+	var/low_pop_minimum_threat = 50
+
+	/// The chance for latejoins to roll when ready
+	var/latejoin_roll_chance = 50
+
+	// == EVERYTHING BELOW THIS POINT SHOULD NOT BE CONFIGURED ==
+
 	/// A list of recorded "snapshots" of the round, stored in the dynamic.json log
 	var/list/datum/dynamic_snapshot/snapshots
 
 	/// The time when the last midround injection was attempted, whether or not it was successful
 	var/last_midround_injection_attempt = 0
-
-	/// The amount to inject when a round event is hijacked
-	var/hijacked_random_event_injection_chance = 50
 
 	/// Whether or not a random event has been hijacked this midround cycle
 	var/random_event_hijacked = HIJACKED_NOTHING
@@ -147,10 +184,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	/// Can differ from the actual threat amount.
 	var/shown_threat
 
-	/// What is the lower bound of when the roundstart annoucement is sent out?
-	var/waittime_l = 600
-	/// What is the higher bound of when the roundstart annoucement is sent out?
-	var/waittime_h = 1800
+	VAR_PRIVATE/next_midround_injection
 
 /datum/game_mode/dynamic/admin_panel()
 	var/list/dat = list("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Game Mode Panel</title></head><body><h1><B>Game Mode Panel</B></h1>")
@@ -179,9 +213,15 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			dat += "[DR.ruletype] - <b>[DR.name]</b><br>"
 	else
 		dat += "none.<br>"
-	dat += "<br>Injection Timers: (<b>[get_injection_chance(dry_run = TRUE)]%</b> latejoin chance, <b>[get_midround_injection_chance(dry_run = TRUE)]%</b> midround chance)<BR>"
+	dat += "<br>Injection Timers: (<b>[get_heavy_midround_injection_chance(dry_run = TRUE)]%</b> heavy midround chance)<BR>"
 	dat += "Latejoin: [(latejoin_injection_cooldown-world.time)>60*10 ? "[round((latejoin_injection_cooldown-world.time)/60/10,0.1)] minutes" : "[(latejoin_injection_cooldown-world.time)] seconds"] <a href='?src=\ref[src];[HrefToken()];injectlate=1'>\[Now!\]</a><BR>"
-	dat += "Midround: [(midround_injection_cooldown-world.time)>60*10 ? "[round((midround_injection_cooldown-world.time)/60/10,0.1)] minutes" : "[(midround_injection_cooldown-world.time)] seconds"] <a href='?src=\ref[src];[HrefToken()];injectmid=1'>\[Now!\]</a><BR>"
+
+	var/next_injection = next_midround_injection()
+	if (next_injection == INFINITY)
+		dat += "All midrounds have been exhausted."
+	else
+		dat += "Midround: [DisplayTimeText(next_injection - world.time)] <a href='?src=\ref[src];[HrefToken()];injectmid=1'>\[Now!\]</a><BR>"
+
 	usr << browse(dat.Join(), "window=gamemode_panel;size=500x500")
 
 /datum/game_mode/dynamic/Topic(href, href_list)
@@ -210,9 +250,9 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		forced_injection = TRUE
 		message_admins("[key_name(usr)] forced a latejoin injection.")
 	else if (href_list["injectmid"])
-		midround_injection_cooldown = 0
 		forced_injection = TRUE
 		message_admins("[key_name(usr)] forced a midround injection.")
+		try_midround_roll()
 	else if (href_list["threatlog"])
 		show_threatlog(usr)
 	else if (href_list["stacking_limit"])
@@ -310,6 +350,9 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/relative_threat = LORENTZ_DISTRIBUTION(threat_curve_centre, threat_curve_width)
 	threat_level = round(lorentz_to_amount(relative_threat), 0.1)
 
+	if(SSticker.totalPlayersReady < low_pop_player_threshold)
+		threat_level = min(threat_level, LERP(low_pop_minimum_threat, max_threat_level, SSticker.totalPlayersReady / low_pop_player_threshold))
+
 	peaceful_percentage = round(LORENTZ_CUMULATIVE_DISTRIBUTION(relative_threat, threat_curve_centre, threat_curve_width), 0.01)*100
 
 /// Generates the midround and roundstart budgets
@@ -341,9 +384,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 /datum/game_mode/dynamic/proc/set_cooldowns()
 	var/latejoin_injection_cooldown_middle = 0.5*(latejoin_delay_max + latejoin_delay_min)
 	latejoin_injection_cooldown = round(clamp(EXP_DISTRIBUTION(latejoin_injection_cooldown_middle), latejoin_delay_min, latejoin_delay_max)) + world.time
-
-	var/midround_injection_cooldown_middle = 0.5*(midround_delay_max + midround_delay_min)
-	midround_injection_cooldown = round(clamp(EXP_DISTRIBUTION(midround_injection_cooldown_middle), midround_delay_min, midround_delay_max)) + world.time
 
 /datum/game_mode/dynamic/pre_setup()
 	if(CONFIG_GET(flag/dynamic_config_enabled))
@@ -585,80 +625,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		if(rule.rule_process() == RULESET_STOP_PROCESSING) // If rule_process() returns 1 (RULESET_STOP_PROCESSING), stop processing.
 			current_rules -= rule
 
-	if (midround_injection_cooldown < world.time)
-		if (GLOB.dynamic_forced_extended)
-			return
-
-		// Somehow it managed to trigger midround multiple times so this was moved here.
-		// There is no way this should be able to trigger an injection twice now.
-		var/midround_injection_cooldown_middle = 0.5*(midround_delay_max + midround_delay_min)
-		midround_injection_cooldown = (round(clamp(EXP_DISTRIBUTION(midround_injection_cooldown_middle), midround_delay_min, midround_delay_max)) + world.time)
-
-		// Time to inject some threat into the round
-		if(EMERGENCY_ESCAPED_OR_ENDGAMED) // Unless the shuttle is gone
-			return
-
-		message_admins("DYNAMIC: Checking for midround injection.")
-		log_game("DYNAMIC: Checking for midround injection.")
-
-		last_midround_injection_attempt = world.time
-
-		if (prob(get_midround_injection_chance()))
-			var/list/drafted_rules = list()
-			for (var/datum/dynamic_ruleset/midround/rule in midround_rules)
-				if (!rule.weight)
-					continue
-				if (rule.acceptable(GLOB.alive_player_list.len, threat_level) && mid_round_budget >= rule.cost)
-					// If admins have disabled dynamic from picking from the ghost pool
-					if(rule.ruletype == "Latejoin" && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))
-						continue
-					rule.trim_candidates()
-					if (rule.ready())
-						drafted_rules[rule] = rule.get_weight()
-			if (drafted_rules.len > 0)
-				pick_midround_rule(drafted_rules)
-		else if (random_event_hijacked == HIJACKED_TOO_SOON)
-			log_game("DYNAMIC: Midround injection failed when random event was hijacked. Spawning another random event in its place.")
-
-			// A random event antag would have rolled had this injection check passed.
-			// As a refund, spawn a non-ghost-role random event.
-			SSevents.spawnEvent()
-			SSevents.reschedule()
-
-		random_event_hijacked = HIJACKED_NOTHING
-
-/// Gets the chance for latejoin injection, the dry_run argument is only used for forced injection.
-/datum/game_mode/dynamic/proc/get_injection_chance(dry_run = FALSE)
-	if(forced_injection)
-		forced_injection = dry_run
-		return 100
-	var/chance = 0
-	var/max_pop_per_antag = max(5,15 - round(threat_level/10) - round(GLOB.alive_player_list.len/5))
-	if (!GLOB.current_living_antags.len)
-		chance += 50 // No antags at all? let's boost those odds!
-	else
-		var/current_pop_per_antag = GLOB.alive_player_list.len / GLOB.current_living_antags.len
-		if (current_pop_per_antag > max_pop_per_antag)
-			chance += min(50, 25+10*(current_pop_per_antag-max_pop_per_antag))
-		else
-			chance += 25-10*(max_pop_per_antag-current_pop_per_antag)
-	if (GLOB.dead_player_list.len > GLOB.alive_player_list.len)
-		chance -= 30 // More than half the crew died? ew, let's calm down on antags
-	if (mid_round_budget > higher_injection_chance_minimum_threat)
-		chance += higher_injection_chance
-	if (mid_round_budget < lower_injection_chance_minimum_threat)
-		chance -= lower_injection_chance
-	return round(max(0,chance))
-
-/// Gets the chance for midround injection, the dry_run argument is only used for forced injection.
-/// Usually defers to the latejoin injection chance.
-/datum/game_mode/dynamic/proc/get_midround_injection_chance(dry_run)
-	var/chance = get_injection_chance(dry_run)
-
-	if (random_event_hijacked != HIJACKED_NOTHING)
-		chance += hijacked_random_event_injection_chance
-
-	return chance
+	try_midround_roll()
 
 /// Removes type from the list
 /datum/game_mode/dynamic/proc/remove_from_list(list/type_list, type)
@@ -693,7 +660,8 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			addtimer(CALLBACK(src, /datum/game_mode/dynamic/.proc/execute_midround_latejoin_rule, forced_latejoin_rule), forced_latejoin_rule.delay)
 		forced_latejoin_rule = null
 
-	else if (latejoin_injection_cooldown < world.time && prob(get_injection_chance()))
+	else if (latejoin_injection_cooldown < world.time && (forced_injection || prob(latejoin_roll_chance)))
+		forced_injection = FALSE
 		var/list/drafted_rules = list()
 		for (var/datum/dynamic_ruleset/latejoin/rule in latejoin_rules)
 			if (!rule.weight)

--- a/code/game/gamemodes/dynamic/dynamic_hijacking.dm
+++ b/code/game/gamemodes/dynamic/dynamic_hijacking.dm
@@ -17,11 +17,9 @@
 	if (world.time - last_midround_injection_attempt < time_range)
 		random_event_hijacked = HIJACKED_TOO_RECENT
 		dynamic_log("Random event [round_event_control.name] tried to roll, but the last midround injection \
-			was too recent. Injection chance has been raised to [get_midround_injection_chance(dry_run = TRUE)]%.")
+			was too recent. Heavy injection chance has been raised to [get_heavy_midround_injection_chance(dry_run = TRUE)]%.")
 		return CANCEL_PRE_RANDOM_EVENT
 
-	if (midround_injection_cooldown - world.time < time_range)
-		random_event_hijacked = HIJACKED_TOO_SOON
-		dynamic_log("Random event [round_event_control.name] tried to roll, but the next midround injection \
-			is too soon. Injection chance has been raised to [get_midround_injection_chance(dry_run = TRUE)]%.")
+	if (next_midround_injection() - world.time < time_range)
+		dynamic_log("Random event [round_event_control.name] tried to roll, but the next midround injection is too soon.")
 		return CANCEL_PRE_RANDOM_EVENT

--- a/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
+++ b/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
@@ -1,0 +1,90 @@
+/// Returns the world.time of the next midround injection.
+/// Will return a cached result from `next_midround_injection`, the variable.
+/// If that variable is null, will generate a new one.
+/datum/game_mode/dynamic/proc/next_midround_injection()
+	if (!isnull(next_midround_injection))
+		return next_midround_injection
+
+	// Admins can futz around with the midround threat, and we want to be able to react to that
+	var/midround_threat = threat_level - round_start_budget
+
+	var/rolls = CEILING(midround_threat / threat_per_midround_roll, 1)
+	var/distance = ((1 / (rolls + 1)) * midround_upper_bound) + midround_lower_bound
+
+	if (last_midround_injection_attempt == 0)
+		last_midround_injection_attempt = SSticker.round_start_time
+
+	return last_midround_injection_attempt + distance
+
+/datum/game_mode/dynamic/proc/try_midround_roll()
+	if (!forced_injection && next_midround_injection() > world.time)
+		return
+
+	if (GLOB.dynamic_forced_extended)
+		return
+
+	if (EMERGENCY_PAST_POINT_OF_NO_RETURN)
+		return
+
+	last_midround_injection_attempt = world.time
+	next_midround_injection = null
+	forced_injection = FALSE
+
+	var/spawn_heavy = prob(get_heavy_midround_injection_chance())
+	dynamic_log("A midround ruleset is rolling, and will be [spawn_heavy ? "HEAVY" : "LIGHT"].")
+
+	random_event_hijacked = HIJACKED_NOTHING
+
+	var/list/drafted_heavies = list()
+	var/list/drafted_lights = list()
+
+	for (var/datum/dynamic_ruleset/midround/ruleset in midround_rules)
+		if (ruleset.weight == 0)
+			continue
+
+		if (!ruleset.acceptable(GLOB.alive_player_list.len, threat_level))
+			continue
+
+		if (mid_round_budget < ruleset.cost)
+			continue
+
+		if (ruleset.minimum_round_time > world.time - SSticker.round_start_time)
+			continue
+
+		// If admins have disabled dynamic from picking from the ghost pool
+		if(istype(ruleset, /datum/dynamic_ruleset/midround/from_ghosts) && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))
+			continue
+
+		ruleset.trim_candidates()
+		if (ruleset.ready())
+			var/ruleset_is_heavy = (ruleset.midround_ruleset_style == MIDROUND_RULESET_STYLE_HEAVY)
+			if (ruleset_is_heavy)
+				drafted_heavies[ruleset] = ruleset.get_weight()
+			else
+				drafted_lights[ruleset] = ruleset.get_weight()
+
+	if (spawn_heavy && drafted_heavies.len > 0 && pick_midround_rule(drafted_heavies))
+		return
+	else if (drafted_lights.len > 0 && pick_midround_rule(drafted_lights))
+		if (spawn_heavy)
+			dynamic_log("A heavy ruleset was intended to roll, but there weren't any available.")
+	else
+		dynamic_log("No midround rulesets could be drafted.")
+
+/// Gets the chance for a heavy ruleset midround injection, the dry_run argument is only used for forced injection.
+/datum/game_mode/dynamic/proc/get_heavy_midround_injection_chance(dry_run)
+	var/chance_modifier = 1
+	var/next_midround_roll = next_midround_injection() - SSticker.round_start_time
+
+	if (random_event_hijacked != HIJACKED_NOTHING)
+		chance_modifier += (hijacked_random_event_injection_chance_modifier / 100)
+
+	if (GLOB.current_living_antags.len == 0)
+		chance_modifier += 0.5
+
+	if (GLOB.dead_player_list.len > GLOB.alive_player_list.len)
+		chance_modifier -= 0.3
+
+	var/heavy_coefficient = CLAMP01((next_midround_roll - midround_light_upper_bound) / (midround_heavy_lower_bound - midround_light_upper_bound))
+
+	return 100 * (heavy_coefficient * max(1, chance_modifier))

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -79,7 +79,7 @@
 	required_candidates = 1
 	weight = 2
 	delay = 1 MINUTES // Prevents rule start while head is offstation.
-	cost = 20
+	cost = 10
 	requirements = list(101,101,70,40,30,20,20,20,20,20)
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/revs)
@@ -152,6 +152,6 @@
 	restricted_roles = list("AI","Cyborg")
 	required_candidates = 1
 	weight = 4
-	cost = 10
+	cost = 7
 	requirements = list(101,101,101,10,10,10,10,10,10,10)
 	repeatable = TRUE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -7,7 +7,6 @@
 
 /datum/dynamic_ruleset/roundstart/traitor
 	name = "Traitors"
-	persistent = TRUE
 	antag_flag = ROLE_TRAITOR
 	antag_datum = /datum/antagonist/traitor
 	minimum_required_age = 0
@@ -19,12 +18,9 @@
 	scaling_cost = 9
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
 	antag_cap = list("denominator" = 24)
-	var/autotraitor_cooldown = (15 MINUTES)
-	COOLDOWN_DECLARE(autotraitor_cooldown_check)
 
 /datum/dynamic_ruleset/roundstart/traitor/pre_execute(population)
 	. = ..()
-	COOLDOWN_START(src, autotraitor_cooldown_check, autotraitor_cooldown)
 	var/num_traitors = get_antag_cap(population) * (scaled_times + 1)
 	for (var/i = 1 to num_traitors)
 		if(candidates.len <= 0)
@@ -35,12 +31,6 @@
 		M.mind.restricted_roles = restricted_roles
 		GLOB.pre_setup_antags += M.mind
 	return TRUE
-
-/datum/dynamic_ruleset/roundstart/traitor/rule_process()
-	if (COOLDOWN_FINISHED(src, autotraitor_cooldown_check))
-		COOLDOWN_START(src, autotraitor_cooldown_check, autotraitor_cooldown)
-		log_game("DYNAMIC: Checking if we can turn someone into a traitor.")
-		mode.picking_specific_rule(/datum/dynamic_ruleset/midround/autotraitor)
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/game/gamemodes/dynamic/readme.md
+++ b/code/game/gamemodes/dynamic/readme.md
@@ -28,20 +28,27 @@ After this process is done, any leftover roundstart threat will be given to the 
 
 ## Deciding midround threats
 
-Latejoin and midround injection cooldowns are set using exponential distribution between
+### Frequency
 
-- 5 minutes and 25 for latejoin (configurable as latejoin_delay_min and latejoin_delay_max)
-- 15 minutes and 35 for midround (configurable as midround_delay_min and midround_delay_max)
+The frequency of midround threats is based on the midround threat of the round. The number of midround threats that will roll is `threat_level` / `threat_per_midround_roll` (configurable), rounded up. For example, if `threat_per_midround_roll` is set to 5, then for every 5 threat, one midround roll will be added. If you have 6 threat, with this configuration, you will get 2 midround rolls.
 
-this value is then added to `world.time` and assigned to the injection cooldown variables.
+These midround roll points are then equidistantly spaced across the round, starting from `midround_lower_bound` (configurable) to `midround_upper_bound` (configurable), with a +/- of `midround_roll_distance` (configurable).
 
-[rigged_roundstart][/datum/game_mode/dynamic/proc/rigged_roundstart] is called instead if there are forced rules (an admin set the mode)
+For example, if:
+1. `midround_lower_bound` is `10 MINUTES`
+2. `midround_upper_bound` is `100 MINUTES`
+3. `midround_roll_distance` is `3 MINUTES`
+4. You have 5 midround rolls for the round
 
-1. [setup_parameters][/datum/game_mode/proc/setup_parameters]\()
-2. [pre_setup][/datum/game_mode/proc/pre_setup]\()
-3. [roundstart][/datum/game_mode/dynamic/proc/roundstart]\() OR [rigged_roundstart][/datum/game_mode/dynamic/proc/rigged_roundstart]\()
-4. [picking_roundstart_rule][/datum/game_mode/dynamic/proc/picking_roundstart_rule]\(drafted_rules)
-5. [post_setup][/datum/game_mode/proc/post_setup]\()
+...then those 5 midround rolls will be placed equidistantly (meaning equally apart) across the first 10-100 minutes of the round. Every individual roll will then be adjusted to either be 3 minutes earlier, or 3 minutes later.
+
+### Threat variety
+
+Threats are split between **heavy** rulesets and **light** rulesets. A heavy ruleset includes major threats like space dragons or blobs, while light rulesets are ones that don't often cause shuttle calls when rolled, such as revenants or traitors (sleeper agents).
+
+When a midround roll occurs, the decision to choose between light or heavy depends on the current round time. If it is less than `midround_light_upper_bound` (configurable), then it is guaranteed to be a light ruleset. If it is more than `midround_heavy_lower_bound`, then it is guaranteed to be a heavy ruleset. If it is any point in between, it will interpolate the value between those. This means that the longer the round goes on, the more likely you are to get a heavy ruleset.
+
+If no heavy ruleset can run, such as not having enough threat, then a light ruleset is guaranteed to run.
 
 ## Rule Processing
 
@@ -153,17 +160,14 @@ Rulesets have the following variables notable to developers and those interested
 - `protected_roles` - Serves the same purpose of `restricted_roles`, except it can be turned off through configuration (`protect_roles_from_antagonist`). For example, security officers *shouldn't* be made traitor, so they are in Traitor's `protected_roles`.
 	- When considering putting a role in `protected_roles` or `restricted_roles`, the rule of thumb is if it is *technically infeasible* to support that job in that role. There's no *technical* reason a security officer can't be a traitor, and so they are simply in `protected_roles`. There *are* technical reasons a cyborg can't be a changeling, so they are in `restricted_roles` instead.
 
+This is not a complete list--search "configurable" in this README to learn more.
+
 ### Dynamic
 
 The "Dynamic" key has the following configurable values:
 - `pop_per_requirement` - The default value of `pop_per_requirement` for any ruleset that does not explicitly set it. Defaults to 6.
 - `latejoin_delay_min`, `latejoin_delay_max` - The time range, in deciseconds (take your seconds, and multiply by 10), for a latejoin to attempt rolling. Once this timer is finished, a new one will be created within the same range.
 	- Suppose you have a `latejoin_delay_min` of 600 (60 seconds, 1 minute) and a `latejoin_delay_max` of 1800 (180 seconds, 3 minutes). Once the round starts, a random number in this range will be picked--let's suppose 1.5 minutes. After 1.5 minutes, Dynamic will decide if a latejoin threat should be created (a probability of `/datum/game_mode/dynamic/proc/get_injection_chance()`). Regardless of its decision, a new timer will be started within the range of 1 to 3 minutes, repeatedly.
-- `midround_delay_min`, `midround_delay_max` - Same as `latejoin_delay_min` and `latejoin_delay_max`, except for midround threats instead of latejoin ones.
-- `higher_injection_chance`, `higher_injection_chance_minimum_threat` - Manipulates the injection chance (`/datum/game_mode/dynamic/proc/get_injection_chance()`). If the *current midround budget* is above `higher_injection_chance_minimum_threat`, then this chance will be increased by `higher_injection_chance`.
-	- For example: suppose you have a `higher_injection_chance_minimum_threat` of 70, and a `higher_injection_chance` of 15. This means that, if when a midround threat is trying to roll, there is 75 midround budget left, then the injection chance will go up 15%.
-- `lower_injection_chance`, `lower_injection_chance_minimum_threat` - The inverse of the `higher_injection_chance` variables. If the *current midround budget* is *below* `lower_injection_chance`, then the chance is lowered by `lower_injection_chance_minimum_threat`.
-	- For example: suppose you have a `lower_injection_chance_minimum_threat` of 30, and a `lower_injection_chance` of 15. This means if there is 20 midround budget left, then the chance will lower by 15%.
 - `threat_curve_centre` - A number between -5 and +5. A negative value will give a more peaceful round and a positive value will give a round with higher threat.
 - `threat_curve_width` - A number between 0.5 and 4. Higher value will favour extreme rounds and lower value rounds closer to the average.
 - `roundstart_split_curve_centre` - A number between -5 and +5. Equivalent to threat_curve_centre, but for the budget split. A negative value will weigh towards midround rulesets, and a positive value will weight towards roundstart ones.
@@ -179,6 +183,6 @@ Random events have the potential to be hijacked by Dynamic to keep the pace of m
 
 In `/datum/game_mode/dynamic/on_pre_random_event` (in `dynamic_hijacking.dm`), Dynamic hooks to random events. If the `dynamic_should_hijack` variable is TRUE, the following sequence of events occurs:
 
-![Flow chart to describe the chain of events for Dynamic 2021 to take](https://user-images.githubusercontent.com/35135081/109071468-9cab7e00-76a8-11eb-8f9f-2b920c602ef4.png)
+![Flow chart to describe the chain of events for Dynamic 2021 to take](https://github.com/tgstation/documentation-assets/blob/main/dynamic/random_event_hijacking.png)
 
-`n` is a random value between `random_event_hijack_minimum` and `random_event_hijack_maximum`. Injection chance, should it need to be raised, is increased by `hijacked_random_event_injection_chance`.
+`n` is a random value between `random_event_hijack_minimum` and `random_event_hijack_maximum`. Heavy injection chance, should it need to be raised, is increased by `hijacked_random_event_injection_chance_modifier`.

--- a/code/game/gamemodes/dynamic/ruleset_picking.dm
+++ b/code/game/gamemodes/dynamic/ruleset_picking.dm
@@ -33,7 +33,7 @@
 /datum/game_mode/dynamic/proc/pick_midround_rule(list/drafted_rules)
 	var/datum/dynamic_ruleset/rule = pick_ruleset(drafted_rules)
 	if (isnull(rule))
-		return
+		return null
 	current_midround_rulesets = drafted_rules - rule
 
 	midround_injection_timer_id = addtimer(
@@ -46,6 +46,8 @@
 	message_admins("DYNAMIC: Executing midround ruleset [rule] in [DisplayTimeText(ADMIN_CANCEL_MIDROUND_TIME)]. \
 		<a href='?src=[REF(src)];cancelmidround=[midround_injection_timer_id]'>CANCEL</a> | \
 		<a href='?src=[REF(src)];differentmidround=[midround_injection_timer_id]'>SOMETHING ELSE</a>")
+
+	return rule
 
 /// Fired after admins do not cancel a midround injection.
 /datum/game_mode/dynamic/proc/execute_midround_rule(datum/dynamic_ruleset/rule)

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	///Name of the antag hud we provide to this mob.
 	var/antag_hud_name
 	/// If set to true, the antag will not be added to the living antag list.
-	var/soft_antag = FALSE
+	var/count_against_dynamic_roll_chance = TRUE
 	/// The battlecry this antagonist shouts when suiciding with C4/X4.
 	var/suicide_cry = ""
 	//Antag panel properties
@@ -88,10 +88,10 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/antagonist/proc/on_body_transfer(mob/living/old_body, mob/living/new_body)
 	SHOULD_CALL_PARENT(TRUE)
 	remove_innate_effects(old_body)
-	if(!soft_antag && old_body.stat != DEAD && !LAZYLEN(old_body.mind?.antag_datums))
+	if(old_body && old_body.stat != DEAD && !LAZYLEN(old_body.mind?.antag_datums))
 		old_body.remove_from_current_living_antags()
 	apply_innate_effects(new_body)
-	if(!soft_antag && new_body.stat != DEAD)
+	if(count_against_dynamic_roll_chance && new_body.stat != DEAD)
 		new_body.add_to_current_living_antags()
 
 //This handles the application of antag huds/special abilities
@@ -155,7 +155,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 		replace_banned_player()
 	else if(owner.current.client?.holder && (CONFIG_GET(flag/auto_deadmin_antagonists) || owner.current.client.prefs?.toggles & DEADMIN_ANTAGONIST))
 		owner.current.client.holder.auto_deadmin()
-	if(!soft_antag && owner.current.stat != DEAD)
+	if(count_against_dynamic_roll_chance && owner.current.stat != DEAD && owner.current.client)
 		owner.current.add_to_current_living_antags()
 
 /**
@@ -194,7 +194,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	remove_innate_effects()
 	clear_antag_moodies()
 	LAZYREMOVE(owner.antag_datums, src)
-	if(!LAZYLEN(owner.antag_datums) && !soft_antag)
+	if(!LAZYLEN(owner.antag_datums))
 		owner.current.remove_from_current_living_antags()
 	if(info_button)
 		QDEL_NULL(info_button)

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -11,6 +11,7 @@
 	prevent_roundtype_conversion = FALSE
 	antagpanel_category = "Ash Walkers"
 	suicide_cry = "I HAVE NO IDEA WHAT THIS THING DOES!!"
+	count_against_dynamic_roll_chance = FALSE
 	var/datum/team/ashwalkers/ashie_team
 
 /datum/antagonist/ashwalker/create_team(datum/team/team)

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -11,7 +11,7 @@
 	prevent_roundtype_conversion = FALSE
 	antagpanel_category = "Ash Walkers"
 	suicide_cry = "I HAVE NO IDEA WHAT THIS THING DOES!!"
-	count_against_dynamic_roll_chance = FALSE
+	count_against_dynamic_roll_chance = FALSE 
 	var/datum/team/ashwalkers/ashie_team
 
 /datum/antagonist/ashwalker/create_team(datum/team/team)

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -34,6 +34,7 @@
 	show_name_in_check_antagonists = TRUE
 	ui_name = "AntagInfoBrainwashed"
 	suicide_cry = "FOR... SOMEONE!!"
+	count_against_dynamic_roll_chance = FALSE
 
 /datum/antagonist/brainwashed/ui_static_data(mob/user)
 	. = ..()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -699,7 +699,7 @@
 	name = "Headslug Changeling"
 	show_in_antagpanel = FALSE
 	give_objectives = FALSE
-	soft_antag = TRUE
+	count_against_dynamic_roll_chance = FALSE
 
 	geneticpoints = 5
 	total_geneticspoints = 5

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -7,6 +7,7 @@
 	antag_hud_name = "obsessed"
 	show_name_in_check_antagonists = TRUE
 	roundend_category = "obsessed"
+	count_against_dynamic_roll_chance = FALSE
 	silent = TRUE //not actually silent, because greet will be called by the trauma anyway.
 	suicide_cry = "FOR MY LOVE!!"
 	var/datum/brain_trauma/special/obsessed/trauma

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -10,6 +10,7 @@
 	show_to_ghosts = TRUE
 	antag_moodlet = /datum/mood_event/focused
 	suicide_cry = "FOR NANOTRASEN!!"
+	count_against_dynamic_roll_chance = FALSE
 	var/datum/team/ert/ert_team
 	var/leader = FALSE
 	var/datum/outfit/outfit = /datum/outfit/centcom/ert/security

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -8,6 +8,7 @@
 	antag_hud_type = ANTAG_HUD_FUGITIVE
 	antag_hud_name = "fugitive"
 	suicide_cry = "FOR FREEDOM!!"
+	count_against_dynamic_roll_chance = FALSE
 	var/datum/team/fugitive/fugitive_team
 	var/is_captured = FALSE
 	var/backstory = "error"

--- a/code/modules/antagonists/fugitive/hunter.dm
+++ b/code/modules/antagonists/fugitive/hunter.dm
@@ -8,6 +8,7 @@
 	antag_hud_type = ANTAG_HUD_FUGITIVE
 	antag_hud_name = "fugitive_hunter"
 	suicide_cry = "FOR GLORY!!"
+	count_against_dynamic_roll_chance = FALSE
 	var/datum/team/fugitive_hunters/hunter_team
 	var/backstory = "error"
 

--- a/code/modules/antagonists/greentext/greentext.dm
+++ b/code/modules/antagonists/greentext/greentext.dm
@@ -3,6 +3,7 @@
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE //Not that it will be there for long
 	suicide_cry = "FOR THE GREENTEXT!!" // This can never actually show up, but not including it is a missed opportunity
+	count_against_dynamic_roll_chance = FALSE
 
 /datum/antagonist/greentext/proc/forge_objectives()
 	var/datum/objective/O = new /datum/objective("Succeed")

--- a/code/modules/antagonists/highlander/highlander.dm
+++ b/code/modules/antagonists/highlander/highlander.dm
@@ -5,6 +5,7 @@
 	show_name_in_check_antagonists = TRUE
 	can_elimination_hijack = ELIMINATION_ENABLED
 	suicide_cry = "FOR SCOTLAND!!" // If they manage to lose their no-drop stuff somehow
+	count_against_dynamic_roll_chance = FALSE
 
 /datum/antagonist/highlander/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/L = owner.current || mob_override

--- a/code/modules/antagonists/valentines/valentine.dm
+++ b/code/modules/antagonists/valentines/valentine.dm
@@ -6,7 +6,6 @@
 	suicide_cry = "FOR MY LOVE!!"
 	count_against_dynamic_roll_chance = FALSE
 	var/datum/mind/date
-	soft_antag = TRUE
 
 /datum/antagonist/valentine/proc/forge_objectives()
 	var/datum/objective/protect/protect_objective = new /datum/objective/protect

--- a/code/modules/antagonists/valentines/valentine.dm
+++ b/code/modules/antagonists/valentines/valentine.dm
@@ -4,6 +4,7 @@
 	show_in_antagpanel = FALSE
 	prevent_roundtype_conversion = FALSE
 	suicide_cry = "FOR MY LOVE!!"
+	count_against_dynamic_roll_chance = FALSE
 	var/datum/mind/date
 	soft_antag = TRUE
 

--- a/code/modules/mob/mob_lists.dm
+++ b/code/modules/mob/mob_lists.dm
@@ -108,7 +108,14 @@
 
 ///Adds the cliented mob reference to the list of living antag player-mobs.
 /mob/proc/add_to_current_living_antags()
-	GLOB.current_living_antags |= src
+
+	if (length(mind.antag_datums) == 0)
+		return
+
+	for (var/datum/antagonist/antagonist in mind.antag_datums)
+		if (antagonist.count_against_dynamic_roll_chance)
+			GLOB.current_living_antags |= src
+			return
 
 ///Removes the mob reference from the list of living antag player-mobs.
 /mob/proc/remove_from_current_living_antags()

--- a/code/modules/unit_tests/dynamic_ruleset_sanity.dm
+++ b/code/modules/unit_tests/dynamic_ruleset_sanity.dm
@@ -2,9 +2,7 @@
 /datum/unit_test/dynamic_roundstart_ruleset_sanity
 
 /datum/unit_test/dynamic_roundstart_ruleset_sanity/Run()
-	for (var/_ruleset in subtypesof(/datum/dynamic_ruleset/roundstart))
-		var/datum/dynamic_ruleset/roundstart/ruleset = _ruleset
-
+	for (var/datum/dynamic_ruleset/roundstart/ruleset as anything in subtypesof(/datum/dynamic_ruleset/roundstart))
 		var/has_scaling_cost = initial(ruleset.scaling_cost)
 		var/is_lone = initial(ruleset.flags) & (LONE_RULESET | HIGH_IMPACT_RULESET)
 
@@ -12,3 +10,8 @@
 			Fail("[ruleset] has a scaling_cost, but is also a lone/highlander ruleset.")
 		else if (!has_scaling_cost && !is_lone)
 			Fail("[ruleset] has no scaling cost, but is also not a lone/highlander ruleset.")
+
+	for (var/datum/dynamic_ruleset/midround/ruleset as anything in subtypesof(/datum/dynamic_ruleset/midround) - /datum/dynamic_ruleset/midround/from_ghosts)
+		var/midround_ruleset_style = initial(ruleset.midround_ruleset_style)
+		if (midround_ruleset_style != MIDROUND_RULESET_STYLE_HEAVY && midround_ruleset_style != MIDROUND_RULESET_STYLE_LIGHT)
+			TEST_FAIL("[ruleset] has an invalid midround_ruleset_style, it should be MIDROUND_RULESET_STYLE_HEAVY or MIDROUND_RULESET_STYLE_LIGHT")

--- a/code/modules/unit_tests/dynamic_ruleset_sanity.dm
+++ b/code/modules/unit_tests/dynamic_ruleset_sanity.dm
@@ -14,4 +14,4 @@
 	for (var/datum/dynamic_ruleset/midround/ruleset as anything in subtypesof(/datum/dynamic_ruleset/midround) - /datum/dynamic_ruleset/midround/from_ghosts)
 		var/midround_ruleset_style = initial(ruleset.midround_ruleset_style)
 		if (midround_ruleset_style != MIDROUND_RULESET_STYLE_HEAVY && midround_ruleset_style != MIDROUND_RULESET_STYLE_LIGHT)
-			TEST_FAIL("[ruleset] has an invalid midround_ruleset_style, it should be MIDROUND_RULESET_STYLE_HEAVY or MIDROUND_RULESET_STYLE_LIGHT")
+			Fail("[ruleset] has an invalid midround_ruleset_style, it should be MIDROUND_RULESET_STYLE_HEAVY or MIDROUND_RULESET_STYLE_LIGHT")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -917,6 +917,7 @@
 #include "code\game\gamemodes\dynamic\dynamic.dm"
 #include "code\game\gamemodes\dynamic\dynamic_hijacking.dm"
 #include "code\game\gamemodes\dynamic\dynamic_logging.dm"
+#include "code\game\gamemodes\dynamic\dynamic_midround_rolling.dm"
 #include "code\game\gamemodes\dynamic\dynamic_rulesets.dm"
 #include "code\game\gamemodes\dynamic\dynamic_rulesets_latejoin.dm"
 #include "code\game\gamemodes\dynamic\dynamic_rulesets_midround.dm"


### PR DESCRIPTION
## About The Pull Request

Ports this one https://github.com/tgstation/tgstation/pull/65997 from tg, check it for more information

## Why It's Good For The Game

Quote from original PR

> Currently, after a random timespan (15 to 35 minutes on LRP, IIRC, higher on MRP), a percent chance is rolled to see if a midround should spawn. This considers several factors in the round, such as number of people dead, number of antags alive, etc.
> 
> This often does a good job of matching the pacing of the round, but too often will a midround not roll when it could have, resulting in a ~30 or so minute wait for the next chance.
> 
> Midround chances also vary in their impact on the round drastically. A new sleeper agent affects the round significantly less than a blob, but both will delay the next roll by the same range, and both will be delayed by the same range.
> 
> Lastly, having a lot of midround threat has far more diminishing returns than having a lot of roundstart threat, precisely because midrounds are not guaranteed to roll, and might not be very common.

## Changelog
:cl: Mothblocks, ported by SuperSlayer
balance: Midround rolls will now happen more frequently, with their power scaling up over time.
/:cl:
