### PR TITLE
Baton stamina damage is now blocked by energy armor

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -239,6 +239,9 @@
 	L.Jitter(20)
 	L.set_confusion(max(confusion_amt, L.get_confusion()))
 	L.stuttering = max(8, L.stuttering)
+	
+	var/obj/item/bodypart/affecting = L.get_bodypart(user.zone_selected)
+	var/armor_block = L.run_armor_check(affecting, ENERGY)
 	L.apply_damage(stamina_loss_amt, STAMINA, BODY_ZONE_CHEST)
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)


### PR DESCRIPTION
## About The Pull Request

Batong stamina damage is now lowered by energy armor, so armor will be more usefull against the them.

## Why It's Good For The Game

Now your cool deathsquad armorcan actually help you

## Changelog
:cl:
balance: Stunbaton stamina damage is now blocked by energy armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
