### PR TITLE
Lowers cooldown on borg cookies and candy

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -42,7 +42,7 @@ RSF
 	///A list of surfaces that we are allowed to place things on.
 	var/list/allowed_surfaces = list(/turf/open/floor, /obj/structure/table)
 	///The unit of mesure of the matter, for use in text
-	var/discriptor = "fabrication-units"
+	var/descriptor = "fabrication-units"
 	///The verb that describes what we're doing, for use in text
 	var/action_type = "Dispensing"
 	///Holds a copy of world.time from the last time the synth was used.
@@ -57,7 +57,7 @@ RSF
 
 /obj/item/rsf/examine(mob/user)
 	. = ..()
-	. += span_notice("It currently holds [matter]/[max_matter] [discriptor].")
+	. += span_notice("It currently holds [matter]/[max_matter] [descriptor].")
 
 /obj/item/rsf/cyborg
 	matter = 30
@@ -66,7 +66,7 @@ RSF
 	if(is_type_in_list(W,matter_by_item))//If the thing we got hit by is in our matter list
 		var/tempMatter = matter_by_item[W.type] + matter
 		if(tempMatter > max_matter)
-			to_chat(user, span_warning("\The [src] can't hold any more [discriptor]!"))
+			to_chat(user, span_warning("\The [src] can't hold any more [descriptor]!"))
 			return
 		if(isstack(W))
 			var/obj/item/stack/stack = W
@@ -75,7 +75,7 @@ RSF
 			qdel(W)
 		matter = tempMatter //We add its value
 		playsound(src.loc, 'sound/machines/click.ogg', 10, TRUE)
-		to_chat(user, span_notice("\The [src] now holds [matter]/[max_matter] [discriptor]."))
+		to_chat(user, span_notice("\The [src] now holds [matter]/[max_matter] [descriptor]."))
 		icon_state = base_icon_state//and set the icon state to the base state
 	else
 		return ..()
@@ -140,11 +140,11 @@ RSF
 		return TRUE
 	else
 		if(matter - 1 < 0)
-			to_chat(user, span_warning("\The [src] doesn't have enough [discriptor] left."))
+			to_chat(user, span_warning("\The [src] doesn't have enough [descriptor] left."))
 			icon_state = spent_icon_state
 			return FALSE
 		matter--
-		to_chat(user, span_notice("\The [src] now holds [matter]/[max_matter] [discriptor]."))
+		to_chat(user, span_notice("\The [src] now holds [matter]/[max_matter] [descriptor]."))
 		return TRUE
 
 ///Helper proc that iterates through all the things we are allowed to spawn on, and sees if the passed atom is one of them
@@ -163,9 +163,9 @@ RSF
 	max_matter = 10
 	cost_by_item = list(/obj/item/food/cookie = 100)
 	dispense_cost = 100
-	discriptor = "cookie-units"
+	descriptor = "cookie-units"
 	action_type = "Fabricates"
-	cooldowndelay = 10 SECONDS
+	cooldowndelay = 2 SECONDS
 	///Tracks whether or not the cookiesynth is about to print a poisoned cookie
 	var/toxin = FALSE //This might be better suited to some initialize fuckery, but I don't have a good "poisoned" sprite
 

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -346,9 +346,9 @@
 	name = "treat fabricator"
 	desc = "Reward humans with various treats. Toggle in-module to switch between dispensing and high velocity ejection modes."
 	icon_state = "lollipop"
-	var/candy = 5
-	var/candymax = 5
-	var/charge_delay = 10 SECONDS
+	var/candy = 10
+	var/candymax = 10
+	var/charge_delay = 3 SECONDS
 	var/charging = FALSE
 	var/mode = DISPENSE_LOLLIPOP_MODE
 
@@ -537,7 +537,7 @@
 
 /obj/projectile/bullet/reusable/lollipop/harmful
 	embedding = list(embed_chance=35, fall_chance=2, jostle_chance=0, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.5, pain_mult=3, rip_time=10)
-	damage = 10
+	damage = 5
 	nodamage = FALSE
 	embed_falloff_tile = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lowers cooldown on cookie and candy generation for borgs. Also increases the amount of candy for the mediborg, and reducing the damage of the gumballs when emagged.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These were never a problem that needed fixing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skog
balance: Peacekeeper borgs can now dispense cookies faster, and mediborgs get more candy storaage and lower cooldown. Lowered the emagged gumball damage to compensate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
