### PR TITLE
Returns xenobio lings

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -20,6 +20,7 @@
 	stat_attack = DEAD
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE
+	gold_core_spawnable = HOSTILE_SPAWN
 	speak_emote = list("squeaks")
 	var/datum/mind/origin
 	var/egg_lain = 0


### PR DESCRIPTION
## About The Pull Request

Re-adds xenobio headslugs as a gold core hostile spawn.

Doesn't need testing because it is just a variable change.

## Why It's Good For The Game

A great wrong has been corrected. Adds fun to the game back.

## Changelog
:cl: SuperSlayer
add: Headslugs are spawnable through xenobiology, again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
