### PR TITLE
Returns standard cyborg module to the game

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -50,6 +50,8 @@
 
 /datum/config_entry/flag/disable_secborg // disallow secborg model to be chosen.
 
+/datum/config_entry/flag/disable_standardborg // disallow standard model to be chosen.
+
 /datum/config_entry/flag/disable_peaceborg
 
 /datum/config_entry/flag/disable_warops

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -679,11 +679,11 @@
 	name = "borg model picker (Standard)"
 	desc = "Allows you to to turn a cyborg into a standard cyborg."
 	icon_state = "cyborg_upgrade3"
-	var/obj/item/robot_model/new_model = null
+	var/obj/item/robot_model/new_model = /obj/item/robot_model/standard
 
 /obj/item/borg/upgrade/transform/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
-	if(. && new_model)
+	if(.)
 		R.model.transform_to(new_model)
 
 /obj/item/borg/upgrade/transform/clown

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -138,15 +138,19 @@
 		to_chat(src,span_userdanger("ERROR: Model installer reply timeout. Please check internal connections."))
 		return
 
-	var/list/model_list = list("Engineering" = /obj/item/robot_model/engineering, \
+	var/list/model_list = list(
+	"Engineering" = /obj/item/robot_model/engineering, \
 	"Medical" = /obj/item/robot_model/medical, \
 	"Miner" = /obj/item/robot_model/miner, \
 	"Janitor" = /obj/item/robot_model/janitor, \
-	"Service" = /obj/item/robot_model/service)
+	"Service" = /obj/item/robot_model/service
+	)
 	if(!CONFIG_GET(flag/disable_peaceborg))
 		model_list["Peacekeeper"] = /obj/item/robot_model/peacekeeper
 	if(!CONFIG_GET(flag/disable_secborg))
 		model_list["Security"] = /obj/item/robot_model/security
+	if(!CONFIG_GET(flag/disable_secborg))
+		model_list["Standard"] = /obj/item/robot_model/standard
 
 	// Create radial menu for choosing borg model
 	var/list/model_icons = list()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -198,6 +198,29 @@
 	return TRUE
 
 // ------------------------------------------ Setting base model modules
+// --------------------- Standart
+/obj/item/robot_model/standard
+	name = "Standard"
+	basic_modules = list(
+		/obj/item/assembly/flash/cyborg,
+		/obj/item/reagent_containers/borghypo/epi,
+		/obj/item/healthanalyzer,
+		/obj/item/weldingtool/largetank/cyborg,
+		/obj/item/wrench/cyborg,
+		/obj/item/crowbar/cyborg,
+		/obj/item/stack/sheet/iron,
+		/obj/item/stack/rods/cyborg,
+		/obj/item/stack/tile/iron/base/cyborg,
+		/obj/item/extinguisher,
+		/obj/item/pickaxe,
+		/obj/item/t_scanner/adv_mining_scanner,
+		/obj/item/restraints/handcuffs/cable/zipties,
+		/obj/item/soap/nanotrasen,
+		/obj/item/borg/cyborghug)
+	emag_modules = list(/obj/item/melee/transforming/energy/sword/cyborg)
+	model_select_icon = "standard"
+	hat_offset = -3
+
 // --------------------- Clown
 /obj/item/robot_model/clown
 	name = "Clown"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -200,7 +200,7 @@
 // ------------------------------------------ Setting base model modules
 // --------------------- Standart
 /obj/item/robot_model/standard
-	name = "Standard"
+	name = "Standard" 
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/reagent_containers/borghypo/epi,

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -264,6 +264,10 @@ ALLOW_AI_MULTICAM
 ## Uncomment to prevent the peacekeeper cyborg model from being chosen
 #DISABLE_PEACEBORG
 
+## Standard Borg ###
+## Uncomment to prevent the standard cyborg model from being chosen
+#DISABLE_STANDARDBORG
+
 ## AWAY MISSIONS ###
 
 ## Uncomment to load the virtual reality hub map


### PR DESCRIPTION
## About The Pull Request

Remake of https://github.com/AetherStation/AetherStation13/pull/213 because I accidentally merged my bloodsucker branch in the standard cyborg module branch.

Adds the standard cyborg module back, and also adds a config option to disable or enable picking of this module.

Tested.
![image](https://user-images.githubusercontent.com/91609255/185738292-b2885f30-7563-4875-bffc-3a0253f5750b.png)

## Why It's Good For The Game

Reverts a stupid TG removal that nobody asked for

## Changelog
:cl:
add: Standard cyborg module
add: A config option to disable/enable standard cyborg module
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
