### PR TITLE
Nerfs plastic flaps

### DIFF
--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -4,7 +4,7 @@
 	gender = PLURAL
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "plasticflaps"
-	armor = list(MELEE = 100, BULLET = 80, LASER = 80, ENERGY = 100, BOMB = 50, BIO = 100, RAD = 100, FIRE = 50, ACID = 50)
+	armor = list(MELEE = 60, BULLET = 40, LASER = 40, ENERGY = 60, BOMB = 50, BIO = 60, RAD = 60, FIRE = 50, ACID = 50)
 	density = FALSE
 	anchored = TRUE
 	CanAtmosPass = ATMOS_PASS_NO


### PR DESCRIPTION
## About The Pull Request

Some really cool guy made them almost immune to all damage sources. There is no reason for then to have them so big armor stats, so this PR reduces their melee, bullet, laser, energy, bio and rad armor by 40. 

## Why It's Good For The Game

Nukie lifes matter

## Changelog
:cl: SuperSlayer
balance: Nerfed plastic flap armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
