### PR TITLE
Add secondary, tgui menu for reflectors

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -254,3 +254,35 @@
 		return
 	else
 		return ..()
+
+/obj/structure/reflector/ui_interact(mob/user, datum/tgui/ui)
+	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
+		return
+	if(!finished)
+		to_chat(user, span_alert("The reflector isn't finished!"))
+		return
+	if(!can_rotate)
+		to_chat(user, span_alert("The rotation is locked!"))
+		return
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "Reflector")
+		ui.open()
+
+/obj/structure/reflector/ui_data(mob/user)
+	var/list/data = list()
+	data["rotation_angle"] = rotation_angle
+
+	return data
+
+/obj/structure/reflector/ui_act(action, params)
+	. = ..()
+	if(.)
+		return
+	if(action == "rotate")
+		if (!can_rotate || admin)
+			return FALSE
+		var/new_angle = params["rotation_angle"]
+		if(!isnull(new_angle))
+			set_angle(SIMPLIFY_DEGREES(new_angle))
+		return TRUE

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -270,6 +270,7 @@
 /obj/structure/reflector/ui_data(mob/user)
 	var/list/data = list()
 	data["rotation_angle"] = rotation_angle
+	data["reflector_name"] = name
 
 	return data
 

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -256,8 +256,6 @@
 		return ..()
 
 /obj/structure/reflector/ui_interact(mob/user, datum/tgui/ui)
-	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
-		return
 	if(!finished)
 		to_chat(user, span_alert("The reflector isn't finished!"))
 		return
@@ -279,10 +277,18 @@
 	. = ..()
 	if(.)
 		return
-	if(action == "rotate")
-		if (!can_rotate || admin)
-			return FALSE
-		var/new_angle = params["rotation_angle"]
-		if(!isnull(new_angle))
-			set_angle(SIMPLIFY_DEGREES(new_angle))
-		return TRUE
+	switch(action)
+		if("rotate")
+			if (!can_rotate || admin)
+				return FALSE
+			var/new_angle = params["rotation_angle"]
+			if(!isnull(new_angle))
+				set_angle(SIMPLIFY_DEGREES(new_angle))
+			return TRUE
+		if("calculate")
+			if (!can_rotate || admin)
+				return FALSE
+			var/new_angle = rotation_angle + params["rotation_angle"]
+			if(!isnull(new_angle))
+				set_angle(SIMPLIFY_DEGREES(new_angle))
+			return TRUE

--- a/tgui/packages/tgui/interfaces/Reflector.js
+++ b/tgui/packages/tgui/interfaces/Reflector.js
@@ -1,0 +1,133 @@
+import { useBackend } from '../backend';
+import { Box, Button, Flex, Stack, Icon, LabeledControls, Section, NumberInput } from '../components';
+import { Window } from '../layouts';
+
+export const Reflector = (props, context) => {
+  const { act, data } = useBackend(context);
+  return (
+    <Window
+      title="Reflector"
+      width={220}
+      height={175}>
+      <Window.Content>
+        <Flex direction="row">
+          <Flex.Item>
+            <Section
+              title="Presets"
+              textAlign="center">
+              <Stack direction="row"
+                align="center">
+                <Stack direction="column" fill>
+                  <Stack.Item>
+                    <Button
+                      icon="arrow-left"
+                      iconRotation={45}
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 315,
+                      })} />
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Button
+                      icon="arrow-left"
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 270,
+                      })} />
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Button
+                      icon="arrow-left"
+                      iconRotation={-45}
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 225,
+                      })} />
+                  </Stack.Item>
+                </Stack>
+                <Stack direction="column" fill>
+                  <Stack.Item>
+                    <Button
+                      icon="arrow-up"
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 0,
+                      })} />
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Icon
+                      name="angle-double-up"
+                      size={2}
+                      rotation={data.rotation_angle}
+                      mb={1}
+                    />
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Button
+                      icon="arrow-down"
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 180,
+                      })} />
+                  </Stack.Item>
+                </Stack>
+                <Stack direction="column" fill>
+                  <Stack.Item>
+                    <Button
+                      icon="arrow-right"
+                      iconRotation={-45}
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 45,
+                      })} />
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Button
+                      icon="arrow-right"
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 90,
+                      })} />
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Button
+                      icon="arrow-right"
+                      iconRotation={45}
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 135,
+                      })} />
+                  </Stack.Item>
+                </Stack>
+              </Stack>
+            </Section>
+          </Flex.Item>
+          <Flex.Item>
+            <Section
+              title="Angle"
+              textAlign="center"
+              fill>
+              <LabeledControls>
+                <LabeledControls.Item label="Angle regulator">
+                  <Box
+                    position="relative">
+                    <NumberInput
+                      value={data.rotation_angle}
+                      unit="degrees"
+                      minValue={0}
+                      maxValue={359}
+                      step={1}
+                      stepPixelSize={2}
+                      onDrag={(e, value) => act('rotate', {
+                        rotation_angle: value,
+                      })} />
+                  </Box>
+                </LabeledControls.Item>
+              </LabeledControls>
+            </Section>
+          </Flex.Item>
+        </Flex>
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/Reflector.js
+++ b/tgui/packages/tgui/interfaces/Reflector.js
@@ -6,7 +6,7 @@ export const Reflector = (props, context) => {
   const { act, data } = useBackend(context);
   return (
     <Window
-      title="Reflector"
+      title={data.reflector_name}
       height={200}
       width={219}>
       <Window.Content>
@@ -129,16 +129,6 @@ export const Reflector = (props, context) => {
                     <Button
                       fluid
                       icon="undo-alt"
-                      content="-1"
-                      mb={1}
-                      onClick={() => act('calculate', {
-                        rotation_angle: -1,
-                      })} />
-                  </Flex.Item>
-                  <Flex.Item>
-                    <Button
-                      fluid
-                      icon="undo-alt"
                       content="-5"
                       mb={1}
                       onClick={() => act('calculate', {
@@ -155,19 +145,18 @@ export const Reflector = (props, context) => {
                         rotation_angle: -10,
                       })} />
                   </Flex.Item>
-                </Flex>
-                <Flex direction="column">
                   <Flex.Item>
                     <Button
                       fluid
-                      icon="redo-alt"
-                      iconPosition="right"
-                      content="+1"
+                      icon="undo-alt"
+                      content="-15"
                       mb={1}
                       onClick={() => act('calculate', {
-                        rotation_angle: 1,
+                        rotation_angle: -15,
                       })} />
                   </Flex.Item>
+                </Flex>
+                <Flex direction="column">
                   <Flex.Item>
                     <Button
                       fluid
@@ -188,6 +177,17 @@ export const Reflector = (props, context) => {
                       mb={1}
                       onClick={() => act('calculate', {
                         rotation_angle: 10,
+                      })} />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="redo-alt"
+                      iconPosition="right"
+                      content="+15"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: 15,
                       })} />
                   </Flex.Item>
                 </Flex>

--- a/tgui/packages/tgui/interfaces/Reflector.js
+++ b/tgui/packages/tgui/interfaces/Reflector.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Box, Button, Flex, Stack, Icon, LabeledControls, Section, NumberInput } from '../components';
+import { Box, Button, Flex, Stack, Icon, LabeledControls, Section, NumberInput, Table } from '../components';
 import { Window } from '../layouts';
 
 export const Reflector = (props, context) => {
@@ -7,18 +7,18 @@ export const Reflector = (props, context) => {
   return (
     <Window
       title="Reflector"
-      width={220}
-      height={175}>
+      height={200}
+      width={219}>
       <Window.Content>
         <Flex direction="row">
           <Flex.Item>
             <Section
               title="Presets"
-              textAlign="center">
-              <Stack direction="row"
-                align="center">
-                <Stack direction="column" fill>
-                  <Stack.Item>
+              textAlign="center"
+              fill>
+              <Table mt={3.5}>
+                <Table.Cell>
+                  <Table.Row>
                     <Button
                       icon="arrow-left"
                       iconRotation={45}
@@ -26,16 +26,16 @@ export const Reflector = (props, context) => {
                       onClick={() => act('rotate', {
                         rotation_angle: 315,
                       })} />
-                  </Stack.Item>
-                  <Stack.Item>
+                  </Table.Row>
+                  <Table.Row>
                     <Button
                       icon="arrow-left"
                       mb={1}
                       onClick={() => act('rotate', {
                         rotation_angle: 270,
                       })} />
-                  </Stack.Item>
-                  <Stack.Item>
+                  </Table.Row>
+                  <Table.Row>
                     <Button
                       icon="arrow-left"
                       iconRotation={-45}
@@ -43,36 +43,38 @@ export const Reflector = (props, context) => {
                       onClick={() => act('rotate', {
                         rotation_angle: 225,
                       })} />
-                  </Stack.Item>
-                </Stack>
-                <Stack direction="column" fill>
-                  <Stack.Item>
+                  </Table.Row>
+                </Table.Cell>
+                <Table.Cell>
+                  <Table.Row>
                     <Button
                       icon="arrow-up"
                       mb={1}
                       onClick={() => act('rotate', {
                         rotation_angle: 0,
                       })} />
-                  </Stack.Item>
-                  <Stack.Item>
-                    <Icon
-                      name="angle-double-up"
-                      size={2}
-                      rotation={data.rotation_angle}
-                      mb={1}
-                    />
-                  </Stack.Item>
-                  <Stack.Item>
+                  </Table.Row>
+                  <Table.Row>
+                    <Box px={0.75}>
+                      <Icon
+                        name="angle-double-up"
+                        size={1.66}
+                        rotation={data.rotation_angle}
+                        mb={1}
+                      />
+                    </Box>
+                  </Table.Row>
+                  <Table.Row>
                     <Button
                       icon="arrow-down"
                       mb={1}
                       onClick={() => act('rotate', {
                         rotation_angle: 180,
                       })} />
-                  </Stack.Item>
-                </Stack>
-                <Stack direction="column" fill>
-                  <Stack.Item>
+                  </Table.Row>
+                </Table.Cell>
+                <Table.Cell>
+                  <Table.Row>
                     <Button
                       icon="arrow-right"
                       iconRotation={-45}
@@ -80,16 +82,16 @@ export const Reflector = (props, context) => {
                       onClick={() => act('rotate', {
                         rotation_angle: 45,
                       })} />
-                  </Stack.Item>
-                  <Stack.Item>
+                  </Table.Row>
+                  <Table.Row>
                     <Button
                       icon="arrow-right"
                       mb={1}
                       onClick={() => act('rotate', {
                         rotation_angle: 90,
                       })} />
-                  </Stack.Item>
-                  <Stack.Item>
+                  </Table.Row>
+                  <Table.Row>
                     <Button
                       icon="arrow-right"
                       iconRotation={45}
@@ -97,9 +99,9 @@ export const Reflector = (props, context) => {
                       onClick={() => act('rotate', {
                         rotation_angle: 135,
                       })} />
-                  </Stack.Item>
-                </Stack>
-              </Stack>
+                  </Table.Row>
+                </Table.Cell>
+              </Table>
             </Section>
           </Flex.Item>
           <Flex.Item>
@@ -108,22 +110,88 @@ export const Reflector = (props, context) => {
               textAlign="center"
               fill>
               <LabeledControls>
-                <LabeledControls.Item label="Angle regulator">
-                  <Box
-                    position="relative">
-                    <NumberInput
-                      value={data.rotation_angle}
-                      unit="degrees"
-                      minValue={0}
-                      maxValue={359}
-                      step={1}
-                      stepPixelSize={2}
-                      onDrag={(e, value) => act('rotate', {
-                        rotation_angle: value,
-                      })} />
-                  </Box>
+                <LabeledControls.Item ml={0.5} label="Set rotation">
+                  <NumberInput
+                    value={data.rotation_angle}
+                    unit="degrees"
+                    minValue={0}
+                    maxValue={359}
+                    step={1}
+                    stepPixelSize={1}
+                    onDrag={(e, value) => act('rotate', {
+                      rotation_angle: value,
+                    })} />
                 </LabeledControls.Item>
               </LabeledControls>
+              <Flex direction="row" grow={1}>
+                <Flex direction="column" grow={1}>
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="undo-alt"
+                      content="-1"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: -1,
+                      })} />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="undo-alt"
+                      content="-5"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: -5,
+                      })} />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="undo-alt"
+                      content="-10"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: -10,
+                      })} />
+                  </Flex.Item>
+                </Flex>
+                <Flex direction="column">
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="redo-alt"
+                      iconPosition="right"
+                      content="+1"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: 1,
+                      })} />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="redo-alt"
+                      iconPosition="right"
+                      content="+5"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: 5,
+                      })} />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="redo-alt"
+                      iconPosition="right"
+                      content="+10"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: 10,
+                      })} />
+                  </Flex.Item>
+                </Flex>
+              </Flex>
             </Section>
           </Flex.Item>
         </Flex>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The lack of responsivness in refrectors hurt me greatly whenever I wanted to make them aim properly, this makes it significantly faster and adds some presets
~~Currently the UI looks like this: ~~
![image](https://user-images.githubusercontent.com/53384660/185815534-2411cf50-59bc-4aa1-bbc9-1ea303cca89d.png)
~~If anyone has an idea how to make the buttons space better there please let me know.~~
Thanks to @TheChosenEvilOne for helping me with making ui better, now it looks like this:

https://user-images.githubusercontent.com/53384660/185946751-589f5f8e-e567-4c9e-8d19-d664087dfeb1.mp4

It also got enchanced with buttons on suggestion from skog, that allow you to change the angle in smaller amounts.

## Why It's Good For The Game
the reflectors are more responsive and can be used for more interesting purposes easier
[lasering.webm](https://user-images.githubusercontent.com/53384660/185815570-e64c195f-ae38-4bd1-9106-6ecedf78bb8f.webm)
It's also easier to finetune the angle so you can aim your emitters with less collateral damage

And in case if tgui doesnt work on your side, the normal way you could rotate the reflectors still works!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
 
expansion: Adds a tgui menu to reflectors, now you can rotate them real time and they have presets too!
 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
