### PR TITLE
Returns pulse slugs to 30 damage

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -119,7 +119,7 @@
 			SSexplosions.medturf += target
 
 /obj/projectile/beam/pulse/shotgun
-	damage = 40
+	damage = 30
 
 /obj/projectile/beam/pulse/heavy
 	name = "heavy pulse laser"


### PR DESCRIPTION
## About The Pull Request

Makes shotgun pulse slugs deal 30 damage because 40 damage is insanely powerfull and stupid amount, it is more then deals desword and also ranged.

## Why It's Good For The Game

Crew shouldn't get deathsquad level weapons

## Changelog
:cl:
balance: Lowered pulse slug damage to 30
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
