### PR TITLE
Fix not being able to alt click rotate TEG circulators.

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -12,6 +12,7 @@
 
 	var/last_pressure_delta = 0
 	pipe_flags = PIPING_ONE_PER_TURF | PIPING_DEFAULT_LAYER_ONLY
+	vent_movement = NONE
 
 	density = TRUE
 
@@ -27,7 +28,7 @@
 
 /obj/machinery/atmospherics/components/binary/circulator/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS )
+	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS )
 
 /obj/machinery/atmospherics/components/binary/circulator/Destroy()
 	if(generator)


### PR DESCRIPTION
## About The Pull Request
Alt click rotate didn't work on circulators because it tried to make you vent crawl.

## Why It's Good For The Game
fixes #240.

## Changelog
:cl:
fix: fixed not being able to rotate TEG circulators with alt-click.
/:cl:
