### PR TITLE
Fixes slime cells having overlays

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -36,7 +36,10 @@
 	var/ratingdesc = TRUE
 	///If it's a grown that acts as a battery, add a wire overlay to it.
 	var/grown_battery = FALSE
-	var/self_recharge = 0 
+	/// Whether or not this cell should self recharge.
+	var/self_recharge = FALSE
+	/// Whether or not this cell should have a charge overlay.
+	var/has_overlay = TRUE
 
 /obj/item/stock_parts/cell/get_cell()
 	return src
@@ -62,6 +65,7 @@
 	SIGNAL_HANDLER
 	UnregisterSignal(reagents, list(COMSIG_REAGENTS_NEW_REAGENT, COMSIG_REAGENTS_ADD_REAGENT, COMSIG_REAGENTS_DEL_REAGENT, COMSIG_REAGENTS_REM_REAGENT, COMSIG_PARENT_QDELETING))
 	return NONE
+
 /obj/item/stock_parts/cell/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	return ..()
@@ -83,9 +87,11 @@
 
 /obj/item/stock_parts/cell/update_overlays()
 	. = ..()
+	if (!has_overlay)
+		return
 	if(grown_battery)
 		. += mutable_appearance('icons/obj/power.dmi', "grown_wires")
-	if(charge < 0.01)
+	if (charge < 0.01)
 		return
 	. += mutable_appearance('icons/obj/power.dmi', "cell-o[((charge / maxcharge) >= 0.995) ? 2 : 1]")
 
@@ -435,6 +441,10 @@
 	grind_results = null
 	rating = 5
 
+/obj/item/stock_parts/cell/crystal_cell/Initialize()
+	. = ..()
+	charge = 50000
+
 /obj/item/stock_parts/cell/high/slime
 	name = "charged slime core"
 	desc = "A yellow slime core infused with plasma, it crackles with power."
@@ -442,14 +452,11 @@
 	icon_state = "yellow slime extract"
 	custom_materials = null
 	rating = 5 //self-recharge makes these desirable
-	self_recharge = 1 // Infused slime cores self-recharge, over time
+	self_recharge = TRUE // Infused slime cores self-recharge, over time
+	has_overlay = FALSE
 
 /*Hypercharged slime cell - located in /code/modules/research/xenobiology/crossbreeding/_misc.dm
 /obj/item/stock_parts/cell/high/slime/hypercharged */
-
-/obj/item/stock_parts/cell/crystal_cell/Initialize()
-	. = ..()
-	charge = 50000
 
 /obj/item/stock_parts/cell/inducer_supply
 	maxcharge = 5000


### PR DESCRIPTION
## About The Pull Request
Removes charge overlays from slime cells.

## Why It's Good For The Game
fixes #246.

## Changelog
:cl:
fix: slime cells no longer have a charge overlay.
/:cl:
