### PR TITLE
Added a SciLock feature to Nanite Cloud Controllers and refinined circuitboard code

### DIFF
--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -19,7 +19,7 @@
 #define ACCESS_MEDICAL 5
 /// Morgue access
 #define ACCESS_MORGUE 6
-/// R&D department and R&D console
+/// R&D department, R&D console and Nanite Cloud Controller
 #define ACCESS_RND 7
 /// Toxins lab and burn chamber
 #define ACCESS_TOXINS 8

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -54,7 +54,10 @@
  * * machine - The machine to attempt to configure.
  */
 /obj/item/circuitboard/proc/configure_machine(obj/machinery/machine)
-	return
+	if (obj_flags & EMAGGED)
+		machine.obj_flags |= EMAGGED
+	else
+		machine.obj_flags &= EMAGGED
 
 // Circuitboard/machine
 /*Common Parts: Parts List: Ignitor, Timer, Infra-red laser, Infra-red sensor, t_scanner, Capacitor, Valve, sensor unit,

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -373,13 +373,13 @@
 	name = "Nanite Cloud Control (Computer Board)"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/nanite_cloud_controller
-	var/scienceLock = TRUE
+	var/science_lock = TRUE
 
 /obj/item/circuitboard/computer/nanite_cloud_controller/multitool_act(mob/living/user)
 	. = ..()
 	if(!(obj_flags & EMAGGED))
-		scienceLock = !scienceLock
-		to_chat(user, span_notice("SciLock set to [scienceLock ? "Enabled" : "Disabled"]."))
+		science_lock = !science_lock
+		to_chat(user, span_notice("SciLock set to [science_lock ? "Enabled" : "Disabled"]."))
 	else
 		to_chat(user, span_alert("The security chip is unresponsive."))
 
@@ -393,7 +393,7 @@
 	if(!istype(machine))
 		CRASH("Science board attempted to configure incorrect machine type: [machine] ([machine?.type])")
 
-	machine.scienceLock = scienceLock
+	machine.science_lock = science_lock
 
 /obj/item/circuitboard/computer/rdconsole
 	name = "R&D Console (Computer Board)"

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -373,6 +373,27 @@
 	name = "Nanite Cloud Control (Computer Board)"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/nanite_cloud_controller
+	var/scienceLock = TRUE
+
+/obj/item/circuitboard/computer/nanite_cloud_controller/multitool_act(mob/living/user)
+	. = ..()
+	if(!(obj_flags & EMAGGED))
+		scienceLock = !scienceLock
+		to_chat(user, span_notice("SciLock set to [scienceLock ? "Enabled" : "Disabled"]."))
+	else
+		to_chat(user, span_alert("The security chip is unresponsive."))
+
+/obj/item/circuitboard/computer/nanite_cloud_controller/emag_act(mob/living/user)
+	if(!(obj_flags & EMAGGED))
+		obj_flags |= EMAGGED
+		to_chat(user, span_notice("You overwrite [src]'s security measures."))
+
+/obj/item/circuitboard/computer/nanite_cloud_controller/configure_machine(obj/machinery/computer/nanite_cloud_controller/machine)
+	. = ..()
+	if(!istype(machine))
+		CRASH("Science board attempted to configure incorrect machine type: [machine] ([machine?.type])")
+
+	machine.scienceLock = scienceLock
 
 /obj/item/circuitboard/computer/rdconsole
 	name = "R&D Console (Computer Board)"
@@ -486,14 +507,11 @@
 		to_chat(user, span_notice("You adjust [src]'s routing and receiver spectrum, unlocking special supplies and contraband."))
 
 /obj/item/circuitboard/computer/cargo/configure_machine(obj/machinery/computer/cargo/machine)
+	. = ..()
 	if(!istype(machine))
 		CRASH("Cargo board attempted to configure incorrect machine type: [machine] ([machine?.type])")
 
 	machine.contraband = contraband
-	if (obj_flags & EMAGGED)
-		machine.obj_flags |= EMAGGED
-	else
-		machine.obj_flags &= ~EMAGGED
 
 /obj/item/circuitboard/computer/cargo/express
 	name = "Express Supply Console (Computer Board)"

--- a/code/modules/research/nanites/nanite_cloud_controller.dm
+++ b/code/modules/research/nanites/nanite_cloud_controller.dm
@@ -208,6 +208,10 @@
 				authenticated = TRUE
 		playsound(src, 'sound/machines/terminal_on.ogg', 50, FALSE)
 		return TRUE
+
+	if (!(obj_flags & EMAGGED) && scienceLock && !authenticated && !issilicon(usr))
+		return
+
 	switch(action)
 		if("eject")
 			eject(usr)

--- a/code/modules/research/nanites/nanite_cloud_controller.dm
+++ b/code/modules/research/nanites/nanite_cloud_controller.dm
@@ -10,7 +10,7 @@
 
 	var/obj/item/disk/nanite_program/disk
 	var/list/datum/nanite_cloud_backup/cloud_backups = list()
-	var/scienceLock = TRUE
+	var/science_lock = TRUE
 	var/current_view = 0 //0 is the main menu, any other number is the page of the backup with that ID
 	var/new_backup_id = 1
 
@@ -90,7 +90,7 @@
 
 	data["authenticated"] = (authenticated || issilicon(user))
 	data["canLogOut"] = !issilicon(user)
-	data["sciLock"] = scienceLock
+	data["sciLock"] = science_lock
 
 	if(disk)
 		data["has_disk"] = TRUE
@@ -209,7 +209,7 @@
 		playsound(src, 'sound/machines/terminal_on.ogg', 50, FALSE)
 		return TRUE
 
-	if (!(obj_flags & EMAGGED) && scienceLock && !authenticated && !issilicon(usr))
+	if (!(obj_flags & EMAGGED) && science_lock && !authenticated && !issilicon(usr))
 		return
 
 	switch(action)

--- a/code/modules/research/nanites/nanite_cloud_controller.dm
+++ b/code/modules/research/nanites/nanite_cloud_controller.dm
@@ -6,11 +6,19 @@
 	circuit = /obj/item/circuitboard/computer/nanite_cloud_controller
 	icon_screen = "nanite_cloud_controller_screen"
 	icon_keyboard = null
+	req_access = list(ACCESS_RND)
 
 	var/obj/item/disk/nanite_program/disk
 	var/list/datum/nanite_cloud_backup/cloud_backups = list()
 	var/current_view = 0 //0 is the main menu, any other number is the page of the backup with that ID
 	var/new_backup_id = 1
+
+/obj/machinery/computer/nanite_cloud_controller/emag_act(mob/user)
+	if (obj_flags & EMAGGED)
+		return
+	obj_flags |= EMAGGED
+	to_chat(user, span_danger("You overwrite the security measures!"))
+	playsound(src, 'sound/machines/terminal_alert.ogg', 50, FALSE)
 
 /obj/machinery/computer/nanite_cloud_controller/Destroy()
 	QDEL_LIST(cloud_backups) //rip backups
@@ -65,8 +73,14 @@
 		ui = new(user, src, "NaniteCloudControl", name)
 		ui.open()
 
-/obj/machinery/computer/nanite_cloud_controller/ui_data()
+/obj/machinery/computer/nanite_cloud_controller/ui_data(mob/user)
 	var/list/data = list()
+
+	if (obj_flags & EMAGGED)
+		data["emagged"] = TRUE
+
+	data["authenticated"] = (authenticated || issilicon(user))
+	data["canLogOut"] = !issilicon(user)
 
 	if(disk)
 		data["has_disk"] = TRUE
@@ -168,6 +182,23 @@
 	. = ..()
 	if(.)
 		return
+	if (action == "toggleAuthentication")
+		if (authenticated)
+			authenticated = FALSE
+			playsound(src, 'sound/machines/terminal_off.ogg', 50, FALSE)
+			return TRUE
+		if (obj_flags & EMAGGED)
+			authenticated = TRUE
+			to_chat(usr, span_warning("[src] lets out a quiet alarm as its login is overridden."))
+			playsound(src, 'sound/machines/terminal_alert.ogg', 25, FALSE)
+		else if(isliving(usr))
+			var/mob/living/L = usr
+			var/obj/item/card/id/id_card = L.get_idcard(hand_first = TRUE)
+			if (check_access(id_card))
+				authenticated = TRUE
+		playsound(src, 'sound/machines/terminal_on.ogg', 50, FALSE)
+		return TRUE
+	if (!authenticated && !issilicon(usr)) return
 	switch(action)
 		if("eject")
 			eject(usr)

--- a/code/modules/research/nanites/nanite_cloud_controller.dm
+++ b/code/modules/research/nanites/nanite_cloud_controller.dm
@@ -10,6 +10,7 @@
 
 	var/obj/item/disk/nanite_program/disk
 	var/list/datum/nanite_cloud_backup/cloud_backups = list()
+	var/scienceLock = TRUE
 	var/current_view = 0 //0 is the main menu, any other number is the page of the backup with that ID
 	var/new_backup_id = 1
 
@@ -19,6 +20,14 @@
 	obj_flags |= EMAGGED
 	to_chat(user, span_danger("You overwrite the security measures!"))
 	playsound(src, 'sound/machines/terminal_alert.ogg', 50, FALSE)
+
+	var/obj/item/circuitboard/computer/nanite_cloud_controller/board = circuit
+	board.obj_flags |= EMAGGED
+	update_static_data(user)
+
+/obj/machinery/computer/nanite_cloud_controller/on_construction()
+	. = ..()
+	circuit.configure_machine(src)
 
 /obj/machinery/computer/nanite_cloud_controller/Destroy()
 	QDEL_LIST(cloud_backups) //rip backups
@@ -81,6 +90,7 @@
 
 	data["authenticated"] = (authenticated || issilicon(user))
 	data["canLogOut"] = !issilicon(user)
+	data["sciLock"] = scienceLock
 
 	if(disk)
 		data["has_disk"] = TRUE
@@ -198,7 +208,6 @@
 				authenticated = TRUE
 		playsound(src, 'sound/machines/terminal_on.ogg', 50, FALSE)
 		return TRUE
-	if (!authenticated && !issilicon(usr)) return
 	switch(action)
 		if("eject")
 			eject(usr)

--- a/tgui/packages/tgui/interfaces/NaniteCloudControl.js
+++ b/tgui/packages/tgui/interfaces/NaniteCloudControl.js
@@ -276,57 +276,75 @@ export const NaniteCloudControl = (props, context) => {
     has_disk,
     current_view,
     new_backup_id,
+    authenticated,
+    canLogOut,
+    emagged,
   } = data;
   return (
     <Window
       width={375}
-      height={700}>
+      height={700}
+      theme={emagged ? "syndicate" : undefined}>
       <Window.Content scrollable>
-        <Section
-          title="Program Disk"
-          buttons={(
+        {(canLogOut || !authenticated) && (
+          <Section title="Authentication">
             <Button
-              icon="eject"
-              content="Eject"
-              disabled={!has_disk}
-              onClick={() => act('eject')} />
-          )}>
-          <NaniteDiskBox />
-        </Section>
-        <Section
-          title="Cloud Storage"
-          buttons={(
-            current_view ? (
-              <Button
-                icon="arrow-left"
-                content="Return"
-                onClick={() => act('set_view', {
-                  view: 0,
-                })} />
-            ) : (
-              <>
-                {"New Backup: "}
-                <NumberInput
-                  value={new_backup_id}
-                  minValue={1}
-                  maxValue={100}
-                  stepPixelSize={4}
-                  width="39px"
-                  onChange={(e, value) => act('update_new_backup_value', {
-                    value: value,
-                  })} />
+              icon={authenticated ? "sign-out-alt" : "sign-in-alt"}
+              content={authenticated ? `Log Out` : "Log In"}
+              color={authenticated ? "bad" : "good"}
+              onClick={() => act("toggleAuthentication")}
+            />
+          </Section>
+        )}
+        {authenticated && (
+          <>
+            <Section
+              title="Program Disk"
+              buttons={(
                 <Button
-                  icon="plus"
-                  onClick={() => act('create_backup')} />
-              </>
-            )
-          )}>
-          {!data.current_view ? (
-            <NaniteCloudBackupList />
-          ) : (
-            <NaniteCloudBackupDetails />
-          )}
-        </Section>
+                  icon="eject"
+                  content="Eject"
+                  disabled={!has_disk}
+                  onClick={() => act('eject')} />
+              )}>
+              <NaniteDiskBox />
+            </Section>
+            <Section
+              title="Cloud Storage"
+              buttons={(
+                current_view ? (
+                  <Button
+                    icon="arrow-left"
+                    content="Return"
+                    onClick={() => act('set_view', {
+                      view: 0,
+                    })} />
+                ) : (
+                  <>
+                    {"New Backup: "}
+                    <NumberInput
+                      value={new_backup_id}
+                      minValue={1}
+                      maxValue={100}
+                      stepPixelSize={4}
+                      width="39px"
+                      onChange={(e, value) => act('update_new_backup_value', {
+                        value: value,
+                      })} />
+                    <Button
+                      icon="plus"
+                      onClick={() => act('create_backup')} />
+                  </>
+                )
+              )}>
+              {!data.current_view ? (
+                <NaniteCloudBackupList />
+              ) : (
+                <NaniteCloudBackupDetails />
+              )}
+            </Section>
+          </>
+        )}
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/NaniteCloudControl.js
+++ b/tgui/packages/tgui/interfaces/NaniteCloudControl.js
@@ -279,6 +279,7 @@ export const NaniteCloudControl = (props, context) => {
     authenticated,
     canLogOut,
     emagged,
+    sciLock,
   } = data;
   return (
     <Window
@@ -286,17 +287,18 @@ export const NaniteCloudControl = (props, context) => {
       height={700}
       theme={emagged ? "syndicate" : undefined}>
       <Window.Content scrollable>
-        {(canLogOut || !authenticated) && (
+        {((canLogOut || !authenticated) && !!sciLock) && (
           <Section title="Authentication">
             <Button
-              icon={authenticated ? "sign-out-alt" : "sign-in-alt"}
-              content={authenticated ? `Log Out` : "Log In"}
+              icon={(authenticated || emagged) ? "sign-out-alt" : "sign-in-alt"}
+              content={(authenticated || emagged) ? `Log Out` : "Log In"}
               color={authenticated ? "bad" : "good"}
               onClick={() => act("toggleAuthentication")}
+              disabled={emagged && authenticated}
             />
           </Section>
         )}
-        {authenticated && (
+        {(!!authenticated || emagged || !sciLock) && (
           <>
             <Section
               title="Program Disk"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR is going to add a brand new feature from the NT for nanite cloud controllers called the SciLock. This feature will require crewmembers' IDs to have RnD access to log into a nanite cloud controller (Borgs and AIs don't have to worry though since they don't have to authenticate). This feature may be disabled with a use of multitool on a borad or hacked with a use of cryptographic sequnecer on a board or the machine itself.

This PR also will improve some circutboard.dm code.

## Why It's Good For The Game

It prevents non-antags from griefing while not gatekeeping nanites to a single department. In addition, there will be another use for the cryptographic sequencer.

Also, some code improvements.

## Changelog
:cl: Polish_User, TCEO, SparkezelPL, TheBleh
add: Added SciLock for Nanite Cloud Controllers
code: Improved configure_machine proc in circuitboard.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
