### PR TITLE
Fixes href exploit in research console.

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -322,6 +322,8 @@ Nothing else in the console has ID requirements.
 			if(QDELETED(d_disk))
 				say("No Design Disk Inserted!")
 				return TRUE
+			if (!(params["selectedDesign"] in stored_research.researched_designs))
+				return
 			var/slot = text2num(params["slot"])
 			var/datum/design/design = SSresearch.techweb_design_by_id(params["selectedDesign"])
 			if(design)


### PR DESCRIPTION
## About The Pull Request
When saving designs to a design disk from a research console the console doesn't actually check if you have that design researched. This PR adds the missing check to `ui_act` of the research console.