### PR TITLE
Fixes href exploit in item stack crafting.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -247,7 +247,7 @@
 			var/datum/stack_recipe/recipe = locate(params["ref"])
 			if(!is_valid_recipe(recipe, recipes)) //href exploit protection
 				return
-			var/multiplier = text2num(params["multiplier"])
+			var/multiplier = round(text2num(params["multiplier"]))
 			if(!multiplier || (multiplier <= 0)) //href exploit protection
 				return
 			if(!building_checks(recipe, multiplier))


### PR DESCRIPTION
## About The Pull Request
With item stack crafting you could modify the UI to set the crafting multiplier to a very tiny number to craft things for practically free. This is easily fixed by just rounding the multiplier.