### PR TITLE
Fixes href exploit in RPD regarding pipe layers.

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -307,7 +307,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 		for(var/obj/machinery/atmospherics/other in target_pipe.nodes)
 			var/index = other.nodes.Find(target_pipe)
 			other.nodes[index] = null
-		
+
 		// Don't spill or lose gas
 		target_pipe.flags_1 |= NODECONSTRUCT_1
 		target_pipe.parent.air.volume -= target_pipe.volume
@@ -327,7 +327,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 		new_pipe.atom_colours = target_pipe.atom_colours
 		new_pipe.update_atom_colour()
 		target_pipe.transfer_fingerprints_to(new_pipe)
-		
+
 		// Feedback
 		play_tool_sound(new_pipe)
 		user.visible_message( \
@@ -428,7 +428,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			p_dir = NORTH
 			playeffect = FALSE
 		if("piping_layer")
-			piping_layer = text2num(params["piping_layer"])
+			piping_layer = clamp(round(text2num(params["piping_layer"])), PIPING_LAYER_MIN, PIPING_LAYER_MAX)
 			playeffect = FALSE
 		if("ducting_layer")
 			ducting_layer = text2num(params["ducting_layer"])


### PR DESCRIPTION
## About The Pull Request
RPD doesn't check if the piping layer set in the UI was actually with in the allowed range.
![image](https://user-images.githubusercontent.com/34602646/186626990-d3ec77c0-989c-47a4-a734-d613c7ff0b35.png)
it also allows decimal layers a seen here:
![image](https://user-images.githubusercontent.com/34602646/186627250-83a0d7d4-8a32-499e-a7a3-68f542a6bb9d.png)
This PR fixes those issues by rounding the value and clamping it in `ui_act`.