### PR TITLE
Nerfs ANFO Severely

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -162,8 +162,7 @@
 /datum/chemical_reaction/reagent_explosion/anfo_explosion
 	required_reagents = list(/datum/reagent/anfo = 1)
 	required_temp = 474
-	strengthdiv = 5
-	modifier = 10
+	strengthdiv = 10
 
 /datum/chemical_reaction/thermite
 	results = list(/datum/reagent/thermite = 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the modifier from ANFO, and doubles the divisor. It will be more like a weaker meth now.

## Why It's Good For The Game

Imagine thoughtfully calculating and designing several multi part explosive chems that require complex recipes and reward you for your hard work with powerful explosives... then some guy adds a reagent with 1:1 ingredient to output ratio that outperforms all but TaTP and nitro (the ones which require lavaland chems) in every single way - easier to make, bigger boom, hell you don't even really need to interact with chemistry, just a biogen and a fuel tank.

## Changelog
:cl:
balance: anfo has been nerfed severely.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
