### PR TITLE
Deathmatch improvements.

### DIFF
--- a/code/modules/deathmatch/deathmatch_controller.dm
+++ b/code/modules/deathmatch/deathmatch_controller.dm
@@ -46,6 +46,7 @@ GLOBAL_VAR(deathmatch_game)
 
 /datum/deathmatch_controller/proc/create_new_lobby(mob/host)
 	lobbies[host.ckey] = new /datum/deathmatch_lobby(host)
+	deadchat_broadcast(" has opened a new deathmatch lobby. <a href=?src=[REF(lobbies[host.ckey])];join=1>(Join)</a>", "<B>[host]</B>")
 
 /datum/deathmatch_controller/proc/remove_lobby(ckey)
 	var/lobby = lobbies[ckey]

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -6,6 +6,7 @@
 	var/list/observers = list()
 	var/datum/deathmatch_map/map
 	var/datum/deathmatch_map_loc/location
+	var/global_chat = FALSE
 	var/playing = FALSE
 	var/ready_count
 	var/list/loadouts
@@ -45,11 +46,12 @@
 /datum/deathmatch_lobby/proc/start_game()
 	if (playing)
 		return
+	playing = TRUE
 	location = game.reserve_location(map)
 	if (!location)
 		to_chat(get_mob_by_ckey(host), span_warning("Couldn't reserve a map location (all locations used?), try again later."))
+		playing = FALSE
 		return FALSE
-	playing = TRUE
 	var/list/spawns = game.load_location(location)
 	if (!spawns)
 		stack_trace("Failed to get spawns when loading deathmatch map [map.name] for lobby [host].")
@@ -76,6 +78,8 @@
 		map.map_equip(H)
 		// register death handling.
 		RegisterSignal(H, COMSIG_LIVING_DEATH, .proc/player_died)
+		if (global_chat)
+			RegisterSignal(H, COMSIG_MOB_SAY, .proc/global_chat)
 		to_chat(H.client, span_reallybig("GO!"))
 		players[K]["mob"] = H
 	// Remove rest of spawns.
@@ -84,6 +88,8 @@
 	for (var/K in observers)
 		var/mob/M = observers[K]["mob"]
 		M.forceMove(location.centre)
+		if (global_chat)
+			RegisterSignal(M, COMSIG_MOB_DEADSAY, .proc/global_chat)
 	log_game("Deathmatch game [host] started.")
 	return TRUE
 
@@ -199,6 +205,8 @@
 		return
 	if (!observers[player.ckey])
 		add_observer(player)
+		if (global_chat)
+			RegisterSignal(player, COMSIG_MOB_DEADSAY, .proc/global_chat)
 	player.forceMove(location.centre)
 
 /datum/deathmatch_lobby/proc/change_map(new_map)
@@ -221,6 +229,24 @@
 			continue
 		players[K]["loadout"] = loadouts[1]
 
+/datum/deathmatch_lobby/proc/global_chat(mob/speaker, message)
+	SIGNAL_HANDLER
+	if (islist(message))
+		message = message[SPEECH_MESSAGE]
+	var/msg = span_prefix("DM: ") + span_name("[speaker.key]") + ": \"[message]\""
+	msg = "<span class='game'>[msg]</span>"
+	for (var/K in players)
+		to_chat(players[K]["mob"], msg)
+	for (var/K in observers)
+		to_chat(observers[K]["mob"], msg)
+
+/datum/deathmatch_lobby/Topic(href, href_list)
+	var/mob/dead/observer/ghost = usr
+	if (!istype(ghost))
+		return
+	if(href_list["join"])
+		join(ghost)
+
 /datum/deathmatch_lobby/ui_state(mob/user)
 	return GLOB.observer_state
 
@@ -241,6 +267,7 @@
 	.["self"] = user.ckey
 	.["host"] = (user.ckey == host)
 	.["admin"] = check_rights_for(user.client, R_ADMIN)
+	.["global_chat"] = global_chat
 	.["loadouts"] = list()
 	for (var/L in loadouts)
 		var/datum/deathmatch_loadout/DML = L
@@ -287,12 +314,6 @@
 			leave(usr.ckey)
 			ui.close()
 			game.ui_interact(usr)
-		if ("change_map")
-			if (playing || host != usr.ckey)
-				return
-			if (!(params["map"] in game.maps))
-				return
-			change_map(params["map"])
 		if ("change_loadout")
 			if (playing)
 				return
@@ -319,7 +340,7 @@
 			if (ready_count >= players.len && players.len >= map.min_players)
 				start_game()
 		if ("host") // Host functions
-			if (playing || (usr.ckey != host || !check_rights(R_ADMIN)))
+			if (playing || (usr.ckey != host && !check_rights(R_ADMIN)))
 				return
 			var/uckey = params["id"]
 			switch (params["func"])
@@ -342,6 +363,12 @@
 					else if (observers[uckey] && players.len < map.max_players)
 						remove_observer(uckey)
 						add_player(umob, loadouts[1], host == uckey)
+				if ("change_map")
+					if (!(params["map"] in game.maps))
+						return
+					change_map(params["map"])
+				if ("global_chat")
+					global_chat = !global_chat
 		if ("admin") // Admin functions
 			if (!check_rights(R_ADMIN))
 				message_admins("[usr.key] has attempted to use admin functions in a deathmatch lobby!")

--- a/tgui/packages/tgui/interfaces/DeathmatchLobby.js
+++ b/tgui/packages/tgui/interfaces/DeathmatchLobby.js
@@ -3,7 +3,6 @@ import { map } from 'common/collections';
 import { Table, Icon, Button, Section, Flex, Box, Dropdown } from '../components';
 import { Window } from '../layouts';
 import { ButtonCheckbox } from '../components/Button';
-import { Fragment } from 'inferno';
 
 export const DeathmatchLobby = (props, context) => {
   const { act, data } = useBackend(context);
@@ -109,7 +108,8 @@ export const DeathmatchLobby = (props, context) => {
                     nochevron
                     displayText={data.map.name}
                     options={data.maps}
-                    onSelected={value => act('change_map', {
+                    onSelected={value => act('host', {
+                      func: "change_map",
                       map: value,
                     })} />
                 ) || (
@@ -124,6 +124,13 @@ export const DeathmatchLobby = (props, context) => {
                 <br />
                 Current players: <b>{Object.keys(data.players).length}</b>
               </Box>
+              <Button.Checkbox
+                checked={data.global_chat}
+                content="Global Chat"
+                tooltip="Allow players and observers to talk with each other."
+                onClick={() => act('host', {
+                  func: "global_chat",
+                })} />
             </Section>
           </Flex.Item>
         </Flex>


### PR DESCRIPTION
## About The Pull Request
Even more improvements to deathmatch.
When creating a lobby a deadchat message is displayed with a link to join, and added a toggleable deathmatch chat.

## Changelog
:cl:
add: Added a dead chat message when a new deathmatch lobby is created.
add: Added chat to deathmatch that can be toggled in lobby.
/:cl: