### PR TITLE
Fix light overlay issues, ports TG PR 60756.

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -250,8 +250,8 @@
 		if(directional)
 			RegisterSignal(new_holder, COMSIG_ATOM_DIR_CHANGE, .proc/on_holder_dir_change)
 	if(overlay_lighting_flags & LIGHTING_ON)
-		make_luminosity_update()
 		add_dynamic_lumi()
+		make_luminosity_update()
 
 
 ///Used to determine the new valid current_holder from the parent's loc.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1024,7 +1024,7 @@
 		// Scale the icon.
 		I.transform *= 0.4
 		// The icon should not rotate.
-		I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+		I.appearance_flags = APPEARANCE_UI
 
 		// Set the direction of the icon animation.
 		var/direction = get_dir(src, A)


### PR DESCRIPTION
## About The Pull Request
Ports tgstation/tgstation#60756.
Yes, this is an ided bug fix PR.

## Changelog
:cl: Couls
fix: bright white spheres when attacking things with an item that has a light source attached
fix: inventory and action buttons creating light sources
/:cl: