### PR TITLE
Robo console cannot do shit with emagged borgs

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -19,6 +19,8 @@
 			return
 	if(R.scrambledcodes)
 		return
+	if(R.emagged)
+		return
 	return TRUE
 
 /obj/machinery/computer/robotics/ui_interact(mob/user, datum/tgui/ui)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Robotics console no longer can interact with emagged cyborgs

## Why It's Good For The Game

Cyborgs are already hatdcountered by many things like flashes or EMP's, and being able to kill them from another part of the station is a peak of stupid hardcounters. This PR mostly aims to make life easier for normall traitors rather then malf AI's, because malf AI's can already easily explode or unpower robo consoles.

## Changelog
:cl:
balance: You no longer can explode emagged borgs via robo console 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
