### PR TITLE
Fixes two issues with antag notes (memory).

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -304,13 +304,13 @@
 
 /datum/dynamic_ruleset/roundstart/bloodcult/execute()
 	main_cult = new
+	main_cult.setup_objectives()
 	for(var/datum/mind/M in assigned)
 		var/datum/antagonist/cult/new_cultist = new antag_datum()
 		new_cultist.cult_team = main_cult
 		new_cultist.give_equipment = TRUE
 		M.add_antag_datum(new_cultist)
 		GLOB.pre_setup_antags -= M
-	main_cult.setup_objectives()
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/bloodcult/round_result()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -54,6 +54,9 @@
 		forge_traitor_objectives()
 		forge_ending_objective()
 
+	if (should_give_codewords)
+		give_codewords()
+
 	var/faction = prob(75) ? FACTION_SYNDICATE : FACTION_NANOTRASEN
 
 	pick_employer(faction)


### PR DESCRIPTION
## About The Pull Request
Fixes #281, also fixes traitors not getting codewords in notes.

## Changelog
:cl:
fix: Fixed roundstart cultist not being informed about their objectives.
fix: Fixed traitors not having codewords in notes.
/:cl:
