### PR TITLE
Added NanoDrug Plus to Meta medbay.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -60541,11 +60541,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "tzK" = (
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
-	},
-/obj/machinery/recharge_station,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "tAg" = (


### PR DESCRIPTION
## About The Pull Request
fixes #280, replaces borg charger in medbay with NanoDrug Plus because silicons have no rights.

## Changelog
:cl:
add: Added a NanoDrug Plus vendor to medbay in MetaStation.
/:cl:
