### PR TITLE
More deathmatch fixes.

### DIFF
--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -59,25 +59,31 @@
 	default_species = /datum/species/human
 	outfit = /datum/outfit/syndicate_empty
 
-/datum/deathmatch_loadout/gunperative
+/datum/deathmatch_loadout/operative/pre_equip(mob/living/carbon/human/player)
+	player.equip_to_slot(new /obj/item/clothing/under/syndicate, ITEM_SLOT_ICLOTHING)
+	player.equip_to_slot(new /obj/item/clothing/gloves/tackler/combat/insulated, ITEM_SLOT_GLOVES)
+	player.equip_to_slot(new /obj/item/clothing/shoes/combat, ITEM_SLOT_FEET)
+	player.equip_to_slot(new /obj/item/storage/backpack, ITEM_SLOT_BACK)
+	player.equip_to_slot(new /obj/item/card/id/chameleon, ITEM_SLOT_ID)
+
+/datum/deathmatch_loadout/operative/ranged
 	name = "Ranged Operative"
 	desc = "A syndicate operative with a gun and a knife."
 	default_species = /datum/species/human
-	outfit = /datum/outfit/syndicate_empty
 	equipment = list(
 		/obj/item/gun/ballistic/automatic/pistol = ITEM_SLOT_HANDS,
 		list(/obj/item/ammo_box/magazine/m9mm = 5) = ITEM_SLOT_BACKPACK,
 		/obj/item/kitchen/knife/combat = ITEM_SLOT_LPOCKET
 	)
 
-/datum/deathmatch_loadout/gunperative/pre_equip(mob/living/carbon/human/player)
+/datum/deathmatch_loadout/operative/ranged/pre_equip(mob/living/carbon/human/player)
 	player.equip_to_slot(new /obj/item/clothing/gloves/combat, ITEM_SLOT_GLOVES)
+	. = ..()
 
-/datum/deathmatch_loadout/meleeperative
+/datum/deathmatch_loadout/operative/melee
 	name = "Melee Operative"
 	desc = "A syndicate operative with multiple knives."
 	default_species = /datum/species/human
-	outfit = /datum/outfit/syndicate_empty
 	equipment = list(
 		/obj/item/clothing/suit/armor/vest = ITEM_SLOT_OCLOTHING,
 		/obj/item/clothing/head/helmet = ITEM_SLOT_HEAD,

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -140,7 +140,7 @@
 	if (players[_mob.ckey])
 		CRASH("Tried to add [_mob.ckey] as an observer while being a player.")
 	if (playing && global_chat)
-		RegisterSignal(player, COMSIG_MOB_DEADSAY, .proc/global_chat)
+		RegisterSignal(_mob, COMSIG_MOB_DEADSAY, .proc/global_chat)
 	observers[_mob.ckey] = list(mob = _mob, host = _host)
 
 /datum/deathmatch_lobby/proc/add_player(mob/_mob, _loadout, _host = FALSE)

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -71,6 +71,8 @@
 		qdel(S)
 		// equip player
 		var/datum/deathmatch_loadout/L = players[K]["loadout"]
+		if (!(L in loadouts))
+			L = loadouts[1]
 		L = new L // agony
 		var/mob/living/carbon/human/H = O.change_mob_type(/mob/living/carbon/human, delete_old_mob = TRUE)
 		clean_player(H)

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -137,6 +137,8 @@
 /datum/deathmatch_lobby/proc/add_observer(mob/_mob, _host = FALSE)
 	if (players[_mob.ckey])
 		CRASH("Tried to add [_mob.ckey] as an observer while being a player.")
+	if (playing && global_chat)
+		RegisterSignal(player, COMSIG_MOB_DEADSAY, .proc/global_chat)
 	observers[_mob.ckey] = list(mob = _mob, host = _host)
 
 /datum/deathmatch_lobby/proc/add_player(mob/_mob, _loadout, _host = FALSE)
@@ -205,8 +207,6 @@
 		return
 	if (!observers[player.ckey])
 		add_observer(player)
-		if (global_chat)
-			RegisterSignal(player, COMSIG_MOB_DEADSAY, .proc/global_chat)
 	player.forceMove(location.centre)
 
 /datum/deathmatch_lobby/proc/change_map(new_map)

--- a/code/modules/deathmatch/deathmatch_maps.dm
+++ b/code/modules/deathmatch/deathmatch_maps.dm
@@ -55,8 +55,8 @@
 	min_players = 2
 	max_players = 5
 	allowed_loadouts = list(
-		/datum/deathmatch_loadout/gunperative,
-		/datum/deathmatch_loadout/meleeperative
+		/datum/deathmatch_loadout/operative/ranged,
+		/datum/deathmatch_loadout/operative/melee
 	)
 	map_path = "_maps/map_files/DM/shooting_range.dmm"
 


### PR DESCRIPTION
## About The Pull Request
Removed headsets from operator loadout, also fixed dying players not getting added to global chat. ALSO ALSO hopefully fixed the weird issue with people being able to play maps with wrong loadouts.

I hate making so many small PRs to fix issues I should have noticed ages ago.

## Changelog
:cl:
fix: removed headset from deathmatch operator loadout.
/:cl: