### PR TITLE
Nerfing HoS Winter Coat

### DIFF
--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -160,7 +160,7 @@
 	desc = "A red, armour-padded winter coat, lovingly woven with a Kevlar interleave and reinforced with semi-ablative polymers and a silver azide fill material. The zipper tab looks like a tiny replica of Beepsky."
 	icon_state = "coathos"
 	inhand_icon_state = "coathos"
-	armor = list(MELEE = 35, BULLET = 25, LASER = 40, ENERGY = 50, BOMB = 35, BIO = 0, RAD = 0, FIRE = 0, ACID = 55)
+	armor = list(MELEE = 35, BULLET = 35, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, RAD = 0, FIRE = 0, ACID = 55)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/security/hos
 
 /obj/item/clothing/head/hooded/winterhood/security/hos


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reducing bomb, laser and energy by 10, increasing bullet by 5 to compensate as unlike other HoS clothes this doesn't cover legs.

## Why It's Good For The Game

Stupid powercreep stats made to tank an extra disabler hit, used by unrobust people, now you can wear it without being a walking talking metaphor for shame. Yes 1 extra disabler hit is a lot when it's 7 instead of 6. Anyone who defends this should not be taken seriously!!!!

## Changelog
:cl:
balance: HoS wintercoat has been rebalanced, it now takes as many disabler hits to down as any other HoS armour.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
