### PR TITLE
Fixes heat disappearing on reinforced floor.

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -590,7 +590,7 @@ Then we space some of our heat, and think about if we should stop conducting.
 
 /turf/open/finish_superconduction()
 	//Conduct with air on my tile if I have it
-	if(!blocks_air)
+	if(!blocks_air && heat_capacity < INFINITY)
 		temperature = air.temperature_share(null, thermal_conductivity, temperature, heat_capacity)
 	..((blocks_air ? temperature : air.temperature))
 


### PR DESCRIPTION
## About The Pull Request
As it turns out engine floor has a heat capacity of INFINITY, and because superconductivity shares gas temperature with floor temperature it just straight up removes heat, very cool.

## Changelog
:cl:
fix: Fixed engine floors destroying gas heat.
/:cl: