### PR TITLE
Makes stasis prevent chem reactions in blood.

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -224,6 +224,7 @@
 		return
 	ADD_TRAIT(owner, TRAIT_IMMOBILIZED, TRAIT_STATUS_EFFECT(id))
 	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, TRAIT_STATUS_EFFECT(id))
+	owner.reagents.flags |= NO_REACT
 	owner.add_filter("stasis_status_ripple", 2, list("type" = "ripple", "flags" = WAVE_BOUNDED, "radius" = 0, "size" = 2))
 	var/filter = owner.get_filter("stasis_status_ripple")
 	animate(filter, radius = 32, time = 15, size = 0, loop = -1)
@@ -235,6 +236,7 @@
 /datum/status_effect/grouped/stasis/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, TRAIT_STATUS_EFFECT(id))
 	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, TRAIT_STATUS_EFFECT(id))
+	owner.reagents.flags &= ~NO_REACT
 	owner.remove_filter("stasis_status_ripple")
 	update_time_of_death()
 	return ..()


### PR DESCRIPTION
## About The Pull Request
Makes stasis stop chem reactions in mobs.

## Why It's Good For The Game
You will be able to do some funny stuff.

## Changelog
:cl:
add: Stasis now stops chem reactions in mobs.
/:cl: