### PR TITLE
Makes custom foods able to hold all reagents of ingredients.

### DIFF
--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -179,6 +179,7 @@
 /datum/component/customizable_reagent_holder/proc/handle_reagents(obj/item/ingredient)
 	var/atom/atom_parent = parent
 	if (atom_parent.reagents && ingredient.reagents)
+		atom_parent.reagents.maximum_volume += ingredient.reagents.total_volume // Make space for ingredient contents
 		ingredient.reagents.trans_to(atom_parent, ingredient.reagents.total_volume)
 	return
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -171,9 +171,10 @@ Behavior that's still missing from this component that original food items had t
 
 	return TryToEat(user, user)
 
-/datum/component/edible/proc/OnFried(datum/source, fry_object)
+/datum/component/edible/proc/OnFried(datum/source, obj/fry_object)
 	SIGNAL_HANDLER
 	var/atom/our_atom = parent
+	fry_object.reagents.maximum_volume = our_atom.reagents.maximum_volume
 	our_atom.reagents.trans_to(fry_object, our_atom.reagents.total_volume)
 	qdel(our_atom)
 	return COMSIG_FRYING_HANDLED


### PR DESCRIPTION
## About The Pull Request
Makes custom food reagent holders get larger when ingredients are added so all reagents can fit, also makes deepfrying food inherit the reagent holder size. (why wasn't this done like this already?)

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/34602646/188309992-5ebcd4a6-89ce-4c75-8827-9bffdc4253b2.png)
Eating this will actually make you really fat.

## Changelog
:cl:
add: Made custom foods able to hold all reagents of added ingredients.
add: Made deepfried items inherit reagent holder volume.
/:cl: