### PR TITLE
makes chem dispensers saner

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -210,7 +210,7 @@
 	if (beaker)
 		data["beakerCurrentVolume"] = round(beakerCurrentVolume, 0.01)
 		data["beakerMaxVolume"] = beaker.volume
-		data["beakerTransferAmounts"] = beaker.possible_transfer_amounts
+		data["beakerTransferAmounts"] = list(5, 10, 15, 20, 25, 30, 50, 100, 300)
 	else
 		data["beakerCurrentVolume"] = null
 		data["beakerMaxVolume"] = null
@@ -248,10 +248,9 @@
 			if(!is_operational || QDELETED(beaker))
 				return
 			var/target = text2num(params["target"])
-			if(target in beaker.possible_transfer_amounts)
-				amount = target
-				work_animation()
-				. = TRUE
+			amount = target
+			work_animation()
+			. = TRUE
 		if("dispense")
 			if(!is_operational || QDELETED(cell))
 				return
@@ -275,7 +274,7 @@
 			if(!is_operational || recording_recipe)
 				return
 			var/amount = text2num(params["amount"])
-			if(beaker && (amount in beaker.possible_transfer_amounts))
+			if(beaker)
 				beaker.reagents.remove_all(amount)
 				work_animation()
 				. = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This will force all chem dispensers to ALWAYS show buttons in range of ( 5, 10, 15, 20, 25, 30, 50, 100, 300 ) which is same as a BS beaker range
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Its fucking stupid when you put a spray into a chemdispenser and you can only rtransfer the amounts in values of 5 or 10 units, or 2/5 for space cleaners
this makes it sane
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Chemdispenser now have fully unlocked reagent synthesis ranges
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
