### PR TITLE
Adjusts medibot heal thresholds.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -180,10 +180,7 @@
 	if(href_list["adj_threshold"])
 		var/adjust_num = text2num(href_list["adj_threshold"])
 		heal_threshold += adjust_num
-		if(heal_threshold < 0)
-			heal_threshold = 0
-		if(heal_threshold > 195)
-			heal_threshold = 195
+		heal_threshold = clamp(heal_threshold, 0, 195)
 
 	else if(href_list["togglevoice"])
 		shut_up = !shut_up

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -180,10 +180,10 @@
 	if(href_list["adj_threshold"])
 		var/adjust_num = text2num(href_list["adj_threshold"])
 		heal_threshold += adjust_num
-		if(heal_threshold < 5)
-			heal_threshold = 5
-		if(heal_threshold > 75)
-			heal_threshold = 75
+		if(heal_threshold < 0)
+			heal_threshold = 0
+		if(heal_threshold > 195)
+			heal_threshold = 195
 
 	else if(href_list["togglevoice"])
 		shut_up = !shut_up


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Medibot healing thresholds have been adjusted:

From 95 / 25 HP.
To 100 / -95 HP.

## Why It's Good For The Game

Allows medibots to actually top you off without RnD upgrades and luck.

## Changelog
:cl:
qol: Medibots now have wider healing thresholds you can set it at.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
