### PR TITLE
Makes unfolded telescopic baton normal size

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -377,7 +377,7 @@
 	on_inhand_icon_state = "nullrod"
 	force_on = 10
 	force_off = 0
-	weight_class_on = WEIGHT_CLASS_BULKY
+	weight_class_on = WEIGHT_CLASS_NORMAL
 	bare_wound_bonus = 5
 
 /obj/item/melee/classic_baton/telescopic/suicide_act(mob/user)


### PR DESCRIPTION

## About The Pull Request
Makes the unfolded telescopic baton normal size.

## Why It's Good For The Game
Allows it to to be put into security belt, brings it in line with the normal baton.


## Changelog
:cl:
fix: Makes the telescopic baton normal size when unfolded.
/:cl:

