### PR TITLE
Fixing And Buffing Sprays

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -64,7 +64,7 @@
 	var/puff_reagent_left = range //how many turf, mob or dense objet we can react with before we consider the chem puff consumed
 	if(stream_mode)
 		reagents.trans_to(reagent_puff, amount_per_transfer_from_this)
-		puff_reagent_left = 1
+		puff_reagent_left = 10
 	else
 		reagents.trans_to(reagent_puff, amount_per_transfer_from_this, 1/range)
 	reagent_puff.color = mix_color_from_reagents(reagent_puff.reagents.reagent_list)
@@ -105,7 +105,7 @@
 					if(!turf_mob.can_inject())
 						continue
 
-					if((turf_mob.body_position == STANDING_UP) || has_travelled_max_distance)
+					if(has_travelled_max_distance)
 						reagent_puff.reagents.expose(turf_mob, VAPOR)
 						log_combat(user, turf_mob, "sprayed", src, addition="which had [puff_reagents_string]")
 						puff_reagent_left -= 1
@@ -339,7 +339,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	throwforce = 0
 	w_class = WEIGHT_CLASS_NORMAL
-	stream_mode = 1
+	stream_mode = 0
 	current_range = 7
 	spray_range = 4
 	stream_range = 7

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -105,10 +105,9 @@
 					if(!turf_mob.can_inject())
 						continue
 
-					if(has_travelled_max_distance)
-						reagent_puff.reagents.expose(turf_mob, VAPOR)
-						log_combat(user, turf_mob, "sprayed", src, addition="which had [puff_reagents_string]")
-						puff_reagent_left -= 1
+					reagent_puff.reagents.expose(turf_mob, VAPOR)
+					log_combat(user, turf_mob, "sprayed", src, addition="which had [puff_reagents_string]")
+					puff_reagent_left -= 1
 				else if(has_travelled_max_distance)
 					reagent_puff.reagents.expose(turf_atom, VAPOR)
 					log_combat(user, turf_atom, "sprayed", src, addition="which had [puff_reagents_string]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases puff_reagent_left tenfold for streams,  removes check for standing up for applying chems to mobs, fixes chem sprayer having stream set to 5u and not 10u.

## Why It's Good For The Game

This stops stream from not working as soon as there is blood or any items on the same turf as the person you are spraying. If it's still cluttered it will block it, covering yourself in a pile of random shit to block chems can be a feature. Nuke op sprayer is incredibly weak, partly because it was bugged, now it isn't and it can go from decent to absurdly strong (if you spray someone against a wall several sprays will hit them at once and they'll get several units of each poison as opposed to usual 3u of each give or take)

## Changelog
:cl:
fix: Spray stream is more likely to effect mobs when tiles have several turfs, biochem sprayer now streams at 10u as opposed to 5u.
balance: Spray stream works on people who are lying down now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
