### PR TITLE
[IDED] [MAJOR SKILL ISSUE] Makes cult stun ignore stun immunity.

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -443,8 +443,8 @@
 
 		else
 			to_chat(user, span_cultitalic("In a brilliant flash of red, [L] falls to the ground!"))
-			L.Paralyze(16 SECONDS)
-			L.flash_act(1,TRUE)
+			L.Paralyze(16 SECONDS, TRUE)
+			L.flash_act(1, TRUE)
 			if(issilicon(target))
 				var/mob/living/silicon/S = L
 				S.emp_act(EMP_HEAVY)


### PR DESCRIPTION
## About The Pull Request
Makes cult stuns ignore stun immunity.

## Why It's Good For The Game
~~Fuck you Delt.~~ Cult is quite powerless early game with the stun being their only tool they can use, when someone gets hulk three minutes in the round and can completely ignore cult stuns it pretty much guarantees cult getting outed. Also cult stun already has it's counter in the form of holy melons and anti-magic in general.

## Changelog
:cl:
balance: cult stun now ignores stun immunity.
/:cl:
