### PR TITLE
Making things right.

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -98,9 +98,11 @@
 	hitsound_on = 'sound/weapons/blade1.ogg'
 	hitsound_off = 'sound/weapons/tap.ogg'
 	damtype_on = BRUTE
-	force_on = 18 //same as epen (but much more obvious)
+	sharpness = SHARP_EDGED
+	armour_penetration = 35
+	force_on = 30 //same as esword (but makes you an epic gamer)
 	light_range = 3 //ditto
-	heat = 0
+	heat = 1000
 
 /obj/item/clothing/head/hardhat/cakehat/energycake/turn_on(mob/living/user)
 	playsound(user, 'sound/weapons/saberon.ogg', 5, TRUE)

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -102,6 +102,7 @@
 	armour_penetration = 35
 	force_on = 30 //same as esword (but makes you an epic gamer)
 	light_range = 3 //ditto
+	light_color = "#08eb2e" //to fit the sprite :)
 	heat = 1000
 
 /obj/item/clothing/head/hardhat/cakehat/energycake/turn_on(mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR will buff Ecak to have simillar damage stats and qualities as an esword.

## Why It's Good For The Game

Ecak is basically an esword put into a cake, therefore, it should have some esword stats preserved. 

## Changelog
:cl:
balance: energy cakehat does esword dmg, can delimb and has esword armour penetration
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
