### PR TITLE
Re-adds the standard cyborg!

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -679,7 +679,7 @@
 	name = "borg model picker (Standard)"
 	desc = "Allows you to to turn a cyborg into a standard cyborg."
 	icon_state = "cyborg_upgrade3"
-	var/obj/item/robot_model/new_model = null
+	var/obj/item/robot_model/new_model = /obj/item/robot_model/standard
 
 /obj/item/borg/upgrade/transform/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -138,7 +138,8 @@
 		to_chat(src,span_userdanger("ERROR: Model installer reply timeout. Please check internal connections."))
 		return
 
-	var/list/model_list = list("Engineering" = /obj/item/robot_model/engineering, \
+	var/list/model_list = list("Standard" = /obj/item/robot_model/standard, \
+	"Engineering" = /obj/item/robot_model/engineering, \
 	"Medical" = /obj/item/robot_model/medical, \
 	"Miner" = /obj/item/robot_model/miner, \
 	"Janitor" = /obj/item/robot_model/janitor, \

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -160,6 +160,10 @@
 	. = ..()
 	model.transform_to(set_model)
 
+// --------------------- Standard
+/mob/living/silicon/robot/model/standard
+	set_model = /obj/item/robot_model/standard
+
 // --------------------- Clown
 /mob/living/silicon/robot/model/clown
 	set_model = /obj/item/robot_model/clown

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -198,6 +198,30 @@
 	return TRUE
 
 // ------------------------------------------ Setting base model modules
+// --------------------- Standard
+/obj/item/robot_model/standard
+	name = "Standard"
+	basic_modules = list(
+		/obj/item/assembly/flash/cyborg,
+		/obj/item/reagent_containers/borghypo/epi,
+		/obj/item/healthanalyzer,
+		/obj/item/weldingtool/largetank/cyborg,
+		/obj/item/wrench/cyborg,
+		/obj/item/crowbar/cyborg,
+		/obj/item/stack/sheet/iron,
+		/obj/item/stack/rods/cyborg,
+		/obj/item/stack/tile/iron/base/cyborg,,
+		/obj/item/extinguisher,
+		/obj/item/pickaxe,
+		/obj/item/t_scanner/adv_mining_scanner,
+		/obj/item/soap/nanotrasen,
+		/obj/item/borg/cyborghug)
+	emag_modules = list(
+	/obj/item/melee/transforming/energy/sword/cyborg,
+	/obj/item/restraints/handcuffs/cable/zipties) //Putting this here since no one likes validhunting borgs.
+	model_select_icon = "standard"
+	hat_offset = -3
+
 // --------------------- Clown
 /obj/item/robot_model/clown
 	name = "Clown"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR re-adds the standard cyborg model!
 - Moved the zipties to the emagged section. I'm sure everyone can appriciate this change.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A standard playstyle is good for borgs who are either new to the game or simply don't know what to do (yet).
Borgs are a different playstyle in their own right, there's no real need to hyper specialize them into certain jobs, especially for LRP servers such as ours.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The default cyborg has returned!
balance: The default cyborg's zipties have been moved to the emag-only section.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
