### PR TITLE
Adds bloodlust and harm-averse quirks

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -28,7 +28,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 							list("Alcohol Tolerance","Light Drinker"), \
 							list("Clown Fan","Mime Fan"), \
 							list("Bad Touch", "Friendly"), \
-							list("Extrovert", "Introvert"))
+							list("Extrovert", "Introvert"), \
+							list("Bloodlust", "Harm-averse"))
 	return ..()
 
 /datum/controller/subsystem/processing/quirks/proc/SetupQuirks()

--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -208,3 +208,24 @@
 	mob_trait = TRAIT_VORACIOUS
 	gain_text = "<span class='notice'>You feel HONGRY.</span>"
 	lose_text = "<span class='danger'>You no longer feel HONGRY.</span>"
+
+/datum/quirk/bloodlust
+	name = "Bloodlust"
+	desc = "Beating people up is fun!"
+	value = 6
+	gain_text = "<span class='notice'> You feel energized by violence.</span>"
+	lose_text = "<span class='danger'> You no longer feel good about hurting others.</span>"
+
+/datum/quirk/bloodlust/add()
+	. = ..()
+	RegisterSignal(quirk_holder,COMSIG_MOB_ATTACK_HAND,.proc/apply_bloodlust)
+
+
+/datum/quirk/bloodlust/remove()
+	. = ..()
+	UnregisterSignal(quirk_holder,COMSIG_MOB_ATTACK_HAND)
+
+/datum/quirk/bloodlust/proc/apply_bloodlust(mob/living/carbon/human/M, mob/living/carbon/human/H, datum/martial_art/attacker_style)
+	if(!M.istate.harm)
+		return
+	M.adjustStaminaLoss(-7.5)

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -804,3 +804,24 @@
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "bad_touch", /datum/mood_event/very_bad_touch)
 	else
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "bad_touch", /datum/mood_event/bad_touch)
+
+/datum/quirk/harm_averse
+	name = "Harm-averse"
+	desc = "You're scared to beat up people"
+	value = -6
+	gain_text = "<span class='notice'> You feel afraid of punch-fights.</span>"
+	lose_text = "<span class='danger'> You feel neutral towards beating people up.</span>"
+
+/datum/quirk/harm_averse/add()
+	. = ..()
+	RegisterSignal(quirk_holder,COMSIG_MOB_ATTACK_HAND,.proc/apply_harm_averse)
+
+/datum/quirk/harm_averse/remove()
+	. = ..()
+	UnregisterSignal(quirk_holder,COMSIG_MOB_ATTACK_HAND)
+
+/datum/quir/harm_averse/proc/apply_harm_averse(mob/living/carbon/human/M, mob/living/carbon/human/H, datum/martial_art/attacker_style)
+	if(!M.istate.harm)
+		return
+	M.adjustStaminaLoss(7.5)
+


### PR DESCRIPTION
## About The Pull Request

Bloodlust - when beating people up using your fists, it regens 7.5 stamina per hit. (6 points)
Harm-averse - when beating people up using your fists, it deals 7.5 stam damage per hit (6 points)


## Why It's Good For The Game

More quirks are always good

## Changelog
:cl:
add: Adds bloodlust quirk that heals 7.5 stamina damage per unarmed melee hit you do
add: Adds harm-averse quirk that deals 7.5 stamina damage per unarmed melee hit you do
/:cl:
