### PR TITLE
Removes useless CO2 filters

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -98158,6 +98158,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/security/prison)
+"wQD" = (
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wQI" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/shoes/magboots{
@@ -126082,7 +126085,7 @@ kne
 hSK
 elR
 aoe
-qLr
+wQD
 ykY
 jJW
 exW

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -48267,7 +48267,6 @@
 "ibV" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
-/obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -54649,10 +54648,6 @@
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/medical/virology)
-"kbD" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "kbN" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/five,
@@ -64989,7 +64984,6 @@
 "ndi" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
-/obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ndr" = (
@@ -80368,9 +80362,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
-	dir = 4
-	},
+/obj/effect/mapping_helpers/simple_pipes/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "rzS" = (
@@ -129427,7 +129419,7 @@ fZv
 swM
 hyV
 rzQ
-kbD
+kPH
 ndi
 ibV
 fuJ

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -44288,8 +44288,8 @@
 /area/commons/dorms)
 "tnP" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2,
 /obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/simple_pipes/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tnR" = (
@@ -84164,7 +84164,7 @@ huM
 vnD
 eqa
 oQl
-mwr
+rLU
 tQD
 tqC
 bWQ
@@ -84421,7 +84421,7 @@ vUh
 rLU
 qnI
 idb
-cXB
+rLU
 sHv
 pbB
 eCB

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -42385,10 +42385,6 @@
 /obj/effect/mapping_helpers/simple_pipes/dark/visible,
 /turf/open/floor/iron/dark/telecomms,
 /area/science/server)
-"fsJ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/closed/wall/r_wall/rust,
-/area/engineering/atmos)
 "fsQ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/simple_pipes/supply/hidden/layer4,
@@ -54174,10 +54170,8 @@
 	name = "atmospherics camera";
 	network = list("ss13","engine")
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/simple_pipes/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kQw" = (
@@ -56389,10 +56383,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"lUX" = (
-/obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "lVw" = (
 /turf/closed/wall/rust,
 /area/command/gateway)
@@ -111637,9 +111627,9 @@ bYL
 bFa
 aRQ
 kFC
-lUX
-lUX
-fsJ
+iVw
+iVw
+qxq
 kQp
 nht
 gnH

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29646,12 +29646,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"inX" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "iob" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/blue{
@@ -38813,10 +38807,6 @@
 /obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/cargo/qm)
-"lNs" = (
-/obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/maintenance/starboard)
 "lNC" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
@@ -39197,10 +39187,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
-"lWr" = (
-/obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "lWB" = (
 /obj/item/cigbutt,
 /obj/machinery/light/small/directional/east,
@@ -43545,10 +43531,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"nuA" = (
-/obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/maintenance/disposal/incinerator)
 "nuE" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/machinery/suit_storage_unit/ce,
@@ -52169,7 +52151,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2,
+/obj/effect/mapping_helpers/simple_pipes/scrubbers/visible,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -63725,7 +63707,6 @@
 "uHb" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/storage/box/lights/mixed,
-/obj/effect/mapping_helpers/simple_pipes/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -112455,7 +112436,7 @@ sRZ
 evA
 teN
 ezE
-lNs
+alq
 ozE
 ozE
 ozE
@@ -112712,7 +112693,7 @@ bVC
 grp
 bYr
 muv
-nuA
+bZE
 mKO
 aaX
 aeD
@@ -112969,7 +112950,7 @@ oCR
 qUk
 apc
 qYi
-nuA
+bZE
 vMe
 adk
 afQ
@@ -113226,7 +113207,7 @@ bPn
 oNh
 nxd
 bZE
-nuA
+bZE
 aGJ
 itV
 stM
@@ -113738,7 +113719,7 @@ pnb
 jod
 cXa
 mhI
-lWr
+apc
 qkN
 aaU
 afQ
@@ -114252,7 +114233,7 @@ bVE
 jMk
 jMk
 vTw
-inX
+jMk
 cSa
 cSa
 vhG


### PR DESCRIPTION

## About The Pull Request

Removes the filters that filtered CO2 back into the waste network, their original purpose was for gasses to always be in the waste network so freezers could use them as heat dumps. Now they are completelly obsolete since our freezers dont output heat while freezing

## Why It's Good For The Game

Waste loop wont clog up on long shifts

## Changelog
:cl:
del: Deleted excessive CO2 filters and pipes associated with them
/:cl:
